### PR TITLE
CMakeLists: Adjust capitalization to work on POSIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,10 @@ project(osmmapmaker VERSION 1.0 LANGUAGES CXX)
 
 find_package(Qt5 REQUIRED COMPONENTS Widgets Core Xml)
 find_package(BZip2)
-find_package(ZLib)
+find_package(ZLIB)
 find_package(EXPAT)
+find_package(SQLite3)
 find_package(SQLiteCpp)
-find_package(sqlite3)
 find_package(PROJ4)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)


### PR DESCRIPTION
With this change, trying to build gets much further on NetBSD, with only two missing modules.

I am unclear on how case sensitivity works on Windows.   It seems inconceivable that the pkgsrc install of cmake has odd capitalization compare to GNU/Linux.