### PR TITLE
Add unit tests for TextFieldProcessor and TileOutput

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,8 @@
   2. Configure using `cmake -S . -B build`.
   3. Build with `cmake --build build -j$(nproc)`.
 
-- **Run unit tests** after building: ensure all tests pass before creating a pull request.
+- **Run unit tests** after building:
+  1. Change into the build directory using `cd build`.
+  2. Execute `ctest --output-on-failure` and make sure every test succeeds before creating a pull request.
 
 - The documentation packages for all third-party dependencies are already installed.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,3 +10,11 @@ add_executable(hello_test hello_test.cpp)
 target_link_libraries(hello_test PRIVATE Catch2::Catch2WithMain mapmaker)
 
 add_test(NAME hello_test COMMAND hello_test)
+
+add_executable(textfieldprocessor_test textfieldprocessor_test.cpp)
+target_link_libraries(textfieldprocessor_test PRIVATE Catch2::Catch2WithMain mapmaker)
+add_test(NAME textfieldprocessor_test COMMAND textfieldprocessor_test)
+
+add_executable(tileoutput_test tileoutput_test.cpp)
+target_link_libraries(tileoutput_test PRIVATE Catch2::Catch2WithMain mapmaker)
+add_test(NAME tileoutput_test COMMAND tileoutput_test)

--- a/tests/textfieldprocessor_test.cpp
+++ b/tests/textfieldprocessor_test.cpp
@@ -1,0 +1,33 @@
+#include <catch2/catch_test_macros.hpp>
+#include "textfield.h"
+#include <set>
+#include <map>
+
+TEST_CASE("TextFieldProcessor RequiredKeys simple", "[TextFieldProcessor]") {
+    std::set<QString> keys;
+    TextFieldProcessor::RequiredKeys("Hello [name]", &keys);
+    REQUIRE(keys.size() == 1);
+    REQUIRE(keys.count(QString("name")) == 1);
+}
+
+TEST_CASE("TextFieldProcessor RequiredKeys multiple and escaping", "[TextFieldProcessor]") {
+    std::set<QString> keys;
+    TextFieldProcessor::RequiredKeys("Path [a,b] and \\[c]", &keys);
+    REQUIRE(keys.size() == 2);
+    REQUIRE(keys.count(QString("a")) == 1);
+    REQUIRE(keys.count(QString("b")) == 1);
+    REQUIRE(keys.count(QString("c")) == 0);
+}
+
+TEST_CASE("TextFieldProcessor Expand", "[TextFieldProcessor]") {
+    std::map<QString, QString> kv;
+    kv["name"] = "OpenAI";
+    REQUIRE(TextFieldProcessor::Expand("Hello [name]", kv) == "Hello OpenAI");
+}
+
+TEST_CASE("TextFieldProcessor Expand with fallback", "[TextFieldProcessor]") {
+    std::map<QString, QString> kv;
+    kv["alt"] = "Buddy";
+    REQUIRE(TextFieldProcessor::Expand("Hello [name, alt]", kv) == "Hello Buddy");
+}
+

--- a/tests/tileoutput_test.cpp
+++ b/tests/tileoutput_test.cpp
@@ -1,0 +1,54 @@
+#include <catch2/catch_test_macros.hpp>
+#include "output.h"
+#include <QtXml>
+
+TEST_CASE("TileOutput default values", "[TileOutput]") {
+    TileOutput out("test");
+    REQUIRE(out.maxZoom() == 18);
+    REQUIRE(out.minZoom() == 13);
+    REQUIRE(out.tileSizePixels() == 256);
+    REQUIRE(out.resolution1x());
+    REQUIRE(out.resolution2x());
+    REQUIRE(out.outputDirectory() == "");
+}
+
+TEST_CASE("TileOutput setters and getters", "[TileOutput]") {
+    TileOutput out("temp");
+    out.setMaxZoom(10);
+    out.setMinZoom(5);
+    out.setTileSizePixels(512);
+    out.setResolution1x(false);
+    out.setResolution2x(false);
+    out.setOutputDirectory("dir");
+
+    REQUIRE(out.maxZoom() == 10);
+    REQUIRE(out.minZoom() == 5);
+    REQUIRE(out.tileSizePixels() == 512);
+    REQUIRE(!out.resolution1x());
+    REQUIRE(!out.resolution2x());
+    REQUIRE(out.outputDirectory() == "dir");
+}
+
+TEST_CASE("TileOutput saveXML populates document", "[TileOutput]") {
+    TileOutput out("xml");
+    out.setMaxZoom(15);
+    out.setMinZoom(8);
+    out.setTileSizePixels(512);
+    out.setResolution1x(false);
+    out.setResolution2x(false);
+    out.setOutputDirectory("outdir");
+
+    QDomDocument doc;
+    QDomElement elem;
+    out.saveXML(doc, elem);
+
+    REQUIRE(elem.tagName() == "tileOutput");
+    REQUIRE(elem.attribute("name") == "xml");
+    REQUIRE(elem.firstChildElement("maxZoom").text() == "15");
+    REQUIRE(elem.firstChildElement("minZoom").text() == "8");
+    REQUIRE(elem.firstChildElement("tileSize").text() == "512");
+    REQUIRE(elem.firstChildElement("resolution1x").text() == "false");
+    REQUIRE(elem.firstChildElement("resolution2x").text() == "false");
+    REQUIRE(elem.firstChildElement("directory").text() == "outdir");
+}
+


### PR DESCRIPTION
## Summary
- document how to run unit tests
- add Catch2 tests for `TextFieldProcessor`
- add Catch2 tests for `TileOutput`
- update test build to include new test executables

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6865f660cdfc8330bea5b5e4fba92323