### PR TITLE
Add bin directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 *.user
+bin/
 vcpkg/
 CMakeCache.txt
 cmake_install.cmake


### PR DESCRIPTION
## Summary
- prevent accidental check-ins of the build output by ignoring `bin/`

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake --build bin/release -j$(nproc)`
- `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build bin/debug -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/debug`
- `ctest --output-on-failure --test-dir bin/release`

------
https://chatgpt.com/codex/tasks/task_e_6865ff1353ac8330930c8dd040849300