### PR TITLE
Remove outdated release build note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ On Debian-based systems you can install them with `install_dependencies.sh`.
 ## TODO
 
 - output GUI, read zooms
-- Create release build
 - Wrap lines by word on lines
 - Add text rendering priority
 - Add support for other marker types for point features; currently only dots are supported


### PR DESCRIPTION
## Summary
- remove the TODO entry for release builds now that they work

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake --build bin/release -j$(nproc)`
- `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build bin/debug -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/debug`
- `ctest --output-on-failure --test-dir bin/release`

------
https://chatgpt.com/codex/tasks/task_e_68660534aba883308f4a4493ff528fd0