### PR TITLE
Fix typos in comments

### DIFF
--- a/mapmaker/stylelayer.cpp
+++ b/mapmaker/stylelayer.cpp
@@ -179,7 +179,7 @@ Label::Label()
 	haloColor_ = QColor(Qt::black);
 	maxWrapWidth_ = 30;
 	offsetY_ = 0;
-	fontWeight = 400; // use ccs font-weight system.
+        fontWeight = 400; // use CSS font-weight system.
 }
 
 QString Label::mapnikText()
@@ -827,7 +827,7 @@ std::vector<QString> StyleLayer::requiredKeys() const
 	sort(keys.begin(), keys.end());
 	keys.erase(std::unique(keys.begin(), keys.end()), keys.end());
 
-	// primary key should't be listed here, it is always in the table
+        // primary key shouldn't be listed here; it is always in the table
 	keys.erase(std::remove(keys.begin(), keys.end(), key_), keys.end());
 
 	return keys;

--- a/osmmapmakerapp/outputTab.cpp
+++ b/osmmapmakerapp/outputTab.cpp
@@ -289,7 +289,7 @@ void OutputTab::on_generate_clicked()
 
 			for (int x = int(px0.first / tileSize); x < int(px1.first / tileSize) + 1; ++x)
 			{
-				// Validate x co - ordinate
+                                // Validate x coordinate
 				if ((x < 0) || (x >= pow(2, z)))
 					continue;
 
@@ -304,13 +304,13 @@ void OutputTab::on_generate_clicked()
 				for (int y = int(px0.second / tileSize); y < yEnd; y += 1)
 				{
 
-					// Validate x co - ordinate
+                                        // Validate y coordinate
 					if ((y < 0) || (y >= pow(2, z)))
 						continue;
 
 					std::string str_y = QString::number(y).toStdString();
 
-					// Submit tile to be rendered into the queue
+                                        // Render tile image
 					//t = (name, tile_uri, x, y, z)
 					if (tileOutput->resolution1x())
 					{
@@ -345,14 +345,13 @@ void OutputTab::RenderTile(RenderQT &render, const path &imagePath, int tileSize
 	std::pair<double, double> l0 = fromPixelToLL(tileSize, p0, z);
 	std::pair<double, double> l1 = fromPixelToLL(tileSize,p1, z);
 
-	// Convert to map projection (e.g. mercator co-ords EPSG:900913)
-	// c0 = self.prj.forward(mapnik.Coord(l0[0], l0[1]));
-	double x0, y0;
-	project_->convertDataToMap(l0.first, l0.second, &x0, &y0);
+        // Convert to map projection coordinates (e.g. mercator EPSG:900913)
+        double x0, y0;
+        project_->convertDataToMap(l0.first, l0.second, &x0, &y0);
 
-	// c1 = self.prj.forward(mapnik.Coord(l1[0], l1[1]));
-	double x1, y1;
-	project_->convertDataToMap(l1.first, l1.second, &x1, &y1);
+        // Convert second point to map projection
+        double x1, y1;
+        project_->convertDataToMap(l1.first, l1.second, &x1, &y1);
 
 	render.SetupZoomBoundingBox(tileSize*resolutionScale, tileSize*resolutionScale, x0, x1, y0, y1);
 

--- a/osmmapmakerapp/styleTab.cpp
+++ b/osmmapmakerapp/styleTab.cpp
@@ -138,19 +138,19 @@ void StyleTab::on_treeNew_clicked()
 
 	if (project_->styleLayers().size() == 0 || currentItem == NULL || currentItem->data(0, Qt::UserRole).toInt() < 0)
 	{
-		// always do top level style if project is empty, nothing is elected, or they have the map node selected.
+                // Always do top level style if project is empty, nothing is selected, or the map node is selected.
 		// otherwise, don't know what style to stick the sub style on.
 		toplevelStyle = true;
 	}
 	else
 	{
-		// othewise we need to ask why kind of new styl 
+                // Otherwise we need to ask what kind of new style
 
 	}
 
 	if ( toplevelStyle)
 	{
-		// top level style, don't eed
+                // Top level style, don't need
 		NewStopLeveStyle dlg(project_, this);
 		if (dlg.exec() == QDialog::Accepted)
 		{
@@ -339,7 +339,7 @@ void StyleTab::on_treeDelete_clicked()
 			}
 			else
 			{
-				// lame hack don't delet the last layer, user can select top level node if this is what they want.
+                                // Lame hack: don't delete the last layer; users can select the top level node if this is what they want.
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- fix misspellings in style layer comments
- clarify coordinate conversion and validation comments in output tab
- correct typos in style tab comments

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake --build bin/release -j$(nproc)`
- `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build bin/debug -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/debug`
- `ctest --output-on-failure --test-dir bin/release`

------
https://chatgpt.com/codex/tasks/task_e_686611dd818c8330802a39ce29323fb3