### PR TITLE
Update build guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,15 @@
 # Instructions for coding agent
 
-- **Build from scratch** before running tests:
+- **Configure CMake build directories** before running tests:
   1. Delete the `bin` directory if it exists.
-  2. Configure a release build using `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`.
-  3. Build with `cmake --build bin/release -j$(nproc)`.
-  4. Configure a debug build using `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug`.
-  5. Build with `cmake --build bin/debug -j$(nproc)`.
+  2. Configure a release build using `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release` – optimized binaries.
+  3. Configure a debug build using `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug` – includes debug symbols.
+  4. Configure a coverage build using `cmake -S . -B bin/coverage -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-O0 -g --coverage" -DCMAKE_CXX_FLAGS="-O0 -g --coverage" -DCMAKE_EXE_LINKER_FLAGS="--coverage"` – enables GCC coverage profiling without optimization.
+  5. Configure a valgrind build using `cmake -S . -B bin/valgrind -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-O0 -g" -DCMAKE_CXX_FLAGS="-O0 -g"` – debug flags help valgrind report accurate stack traces; optimization isn't required but is usually disabled.
 
-- **Run unit tests** after both builds:
+- **Build each directory** with `cmake --build bin/<type> -j$(nproc)`.
+
+- **Run unit tests** after the release and debug builds:
   1. `ctest --test-dir bin/release`.
   2. `ctest --test-dir bin/debug`.
   3. Execute `ctest --output-on-failure --test-dir bin/release` (or `--test-dir bin/debug`) and make sure every test succeeds before creating a pull request.


### PR DESCRIPTION
## Summary
- refine coverage and valgrind build flags
- clarify valgrind optimization note

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release` *(fails: Qt5XmlPatterns missing)*
- `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug` *(fails: Qt5XmlPatterns missing)*
- `cmake -S . -B bin/coverage -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-O0 -g --coverage" -DCMAKE_CXX_FLAGS="-O0 -g --coverage" -DCMAKE_EXE_LINKER_FLAGS="--coverage"` *(fails)*
- `cmake -S . -B bin/valgrind -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-O0 -g" -DCMAKE_CXX_FLAGS="-O0 -g"` *(fails)*
- `cmake --build bin/release -j$(nproc)` *(fails: no makefile)*
- `cmake --build bin/debug -j$(nproc)` *(fails: no makefile)*
- `cmake --build bin/coverage -j$(nproc)` *(fails: no makefile)*
- `cmake --build bin/valgrind -j$(nproc)` *(fails: no makefile)*
- `ctest --test-dir bin/release` *(no tests found)*
- `ctest --test-dir bin/debug` *(no tests found)*
- `ctest --output-on-failure --test-dir bin/release` *(no tests found)*


------
https://chatgpt.com/codex/tasks/task_e_6866e8c215088330a67f6748b80f06a6