### PR TITLE
Add coverage/valgrind build options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@
   1. Delete the `bin` directory if it exists.
   2. Configure a release build using `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release` – optimized binaries.
   3. Configure a debug build using `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug` – includes debug symbols.
-  4. Configure a coverage build using `cmake -S . -B bin/coverage -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-O0 -g --coverage" -DCMAKE_CXX_FLAGS="-O0 -g --coverage" -DCMAKE_EXE_LINKER_FLAGS="--coverage"` – enables GCC coverage profiling without optimization.
-  5. Configure a valgrind build using `cmake -S . -B bin/valgrind -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-O0 -g" -DCMAKE_CXX_FLAGS="-O0 -g"` – debug flags help valgrind report accurate stack traces; optimization isn't required but is usually disabled.
+  4. Configure a coverage build using `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON` – automatically sets a Debug build and enables GCC coverage profiling.
+  5. Configure a valgrind build using `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON` – automatically sets a Debug build with flags suitable for valgrind analysis.
 
 - **Build each directory** with `cmake --build bin/<type> -j$(nproc)`.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.20)
 
 project(osmmapmaker VERSION 1.0 LANGUAGES CXX)
 
+option(OSMMAPMAKER_ENABLE_COVERAGE "Enable GCC coverage flags" OFF)
+option(OSMMAPMAKER_ENABLE_VALGRIND "Enable flags suitable for valgrind" OFF)
+
 find_package(Qt5 REQUIRED COMPONENTS Widgets Core Xml XmlPatterns)
 find_package(BZip2 REQUIRED)
 find_package(ZLIB REQUIRED)
@@ -17,6 +20,23 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(OSMMAPMAKER_ENABLE_COVERAGE)
+  if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Debug CACHE STRING "" FORCE)
+  endif()
+  foreach(VAR CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    string(APPEND ${VAR} " -O0 -g --coverage")
+  endforeach()
+  string(APPEND CMAKE_EXE_LINKER_FLAGS " --coverage")
+elseif(OSMMAPMAKER_ENABLE_VALGRIND)
+  if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Debug CACHE STRING "" FORCE)
+  endif()
+  foreach(VAR CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    string(APPEND ${VAR} " -O0 -g")
+  endforeach()
+endif()
 
 if(WIN32)
   add_compile_definitions(


### PR DESCRIPTION
## Summary
- add configuration flags `OSMMAPMAKER_ENABLE_COVERAGE` and `OSMMAPMAKER_ENABLE_VALGRIND`
- update instructions on how to configure coverage and valgrind builds
- these flags automatically set `CMAKE_BUILD_TYPE=Debug` if not specified

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug`
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/debug -j$(nproc)`
- `cmake --build bin/coverage -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/debug`
- `ctest --output-on-failure --test-dir bin/release`


------
https://chatgpt.com/codex/tasks/task_e_6866ecef9cbc8330a671c24a6d849cbc