### PR TITLE
Update vcpkg Windows deps

### DIFF
--- a/vcpkg-setup.bat
+++ b/vcpkg-setup.bat
@@ -1,10 +1,9 @@
 cd vcpkg
 
-vcpkg install mapnik[cairo,sqlite3] --triplet x64-windows
-
-rem vcpkg install geos libosmium sqlitecpp qt5-tools qt5-imageformats qt5-location --triplet x64-windows
-
-
+rem Install all libraries required by the CMake build files
+vcpkg install qt5-base qt5-tools qt5-xmlpatterns ^
+    bzip2 zlib expat proj4 sqlite3 sqlitecpp geos libosmium catch2 ^
+    --triplet x64-windows
 
 cd ..
 


### PR DESCRIPTION
## Summary
- sync the Windows vcpkg helper with the dependencies listed in the CMake configuration

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release` *(fails: Qt5XmlPatterns missing)*
- `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug` *(fails: Qt5XmlPatterns missing)*
- `cmake -S . -B bin/coverage -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-O0 -g --coverage" -DCMAKE_CXX_FLAGS="-O0 -g --coverage" -DCMAKE_EXE_LINKER_FLAGS="--coverage"` *(fails: Qt5XmlPatterns missing)*
- `cmake -S . -B bin/valgrind -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-O0 -g" -DCMAKE_CXX_FLAGS="-O0 -g"` *(fails: Qt5XmlPatterns missing)*
- `ctest --test-dir bin/release` *(no tests found)*
- `ctest --test-dir bin/debug` *(no tests found)*
- `ctest --output-on-failure --test-dir bin/release` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f12231048330868c2422ae47e689