### PR TITLE
Fix helgrind suppression file

### DIFF
--- a/valgrind.supp
+++ b/valgrind.supp
@@ -68,13 +68,24 @@
 }
 {
    QtHelgrindAllRace
-   Helgrind
+   Helgrind:Race
    ...
    obj:/usr/lib/x86_64-linux-gnu/libQt5*
 }
 {
    QtHelgrindAllMutex
-   Helgrind
+   Helgrind:Race
    ...
    obj:/usr/lib/x86_64-linux-gnu/libQt5*
+}
+
+{
+   QtHelgrindPthreadDestroyNetwork
+   Helgrind:Race
+   obj:*libQt5Network.so*
+}
+{
+   QtHelgrindPthreadDestroyCore
+   Helgrind:Race
+   obj:*libQt5Core.so*
 }


### PR DESCRIPTION
## Summary
- correct invalid Helgrind sections in `valgrind.supp`
- add suppressions for Qt related helgrind noise

## Testing
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/valgrind`
- `valgrind --tool=memcheck --suppressions=valgrind.supp bin/valgrind/tests/hello_test`
- `valgrind --tool=helgrind --suppressions=valgrind.supp bin/valgrind/tests/hello_test`


------
https://chatgpt.com/codex/tasks/task_e_686701131818833081e87a67d9c5c8c6