### PR TITLE
Add Output and TileOutput tests

### DIFF
--- a/tests/tileoutput_test.cpp
+++ b/tests/tileoutput_test.cpp
@@ -54,3 +54,46 @@ TEST_CASE("TileOutput saveXML populates document", "[TileOutput]")
     REQUIRE(elem.firstChildElement("resolution2x").text() == "false");
     REQUIRE(elem.firstChildElement("directory").text() == "outdir");
 }
+
+TEST_CASE("Output XML serialization and loading", "[Output]")
+{
+    QDomDocument doc;
+    QDomElement elem = doc.createElement("output");
+    elem.setAttribute("name", "base");
+    Output base(elem);
+    REQUIRE(base.name() == "base");
+    base.setName("changed");
+
+    QDomDocument saveDoc;
+    QDomElement saveElem = saveDoc.createElement("output");
+    base.saveXML(saveDoc, saveElem);
+    REQUIRE(saveElem.attribute("name") == "changed");
+}
+
+TEST_CASE("TileOutput constructed from DOM", "[TileOutput]")
+{
+    QDomDocument doc;
+    QDomElement elem = doc.createElement("tileOutput");
+    elem.setAttribute("name", "dom");
+
+    auto addChild = [&](const QString& n, const QString& t) {
+        QDomElement child = doc.createElement(n);
+        child.appendChild(doc.createTextNode(t));
+        elem.appendChild(child);
+    };
+    addChild("maxZoom", "20");
+    addChild("minZoom", "5");
+    addChild("tileSize", "128");
+    addChild("resolution1x", "false");
+    addChild("resolution2x", "true");
+    addChild("directory", "out");
+
+    TileOutput loaded(elem);
+    REQUIRE(loaded.name() == "dom");
+    REQUIRE(loaded.maxZoom() == 20);
+    REQUIRE(loaded.minZoom() == 5);
+    REQUIRE(loaded.tileSizePixels() == 128);
+    REQUIRE(!loaded.resolution1x());
+    REQUIRE(loaded.resolution2x());
+    REQUIRE(loaded.outputDirectory() == "out");
+}


### PR DESCRIPTION
## Summary
- expand TileOutput unit tests to include Output class
- test DOM-based TileOutput construction
- verify Output serialization logic

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake --build bin/release -j$(nproc)`
- `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build bin/debug -j$(nproc)`
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake --build bin/coverage -j$(nproc)`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/valgrind`
- `valgrind --tool=memcheck --quiet --suppressions=valgrind.supp bin/valgrind/tests/hello_test`
- `valgrind --tool=memcheck --quiet --suppressions=valgrind.supp bin/valgrind/tests/textfieldprocessor_test`
- `valgrind --tool=memcheck --quiet --suppressions=valgrind.supp bin/valgrind/tests/tileoutput_test`
- `valgrind --tool=memcheck --quiet --suppressions=valgrind.supp bin/valgrind/tests/project_schema_test`
- `valgrind --tool=memcheck --quiet --suppressions=valgrind.supp bin/valgrind/tests/labelpriority_test`
- `valgrind --tool=helgrind --quiet --suppressions=valgrind.supp bin/valgrind/tests/hello_test`
- `valgrind --tool=helgrind --quiet --suppressions=valgrind.supp bin/valgrind/tests/textfieldprocessor_test`
- `valgrind --tool=helgrind --quiet --suppressions=valgrind.supp bin/valgrind/tests/tileoutput_test`
- `valgrind --tool=helgrind --quiet --suppressions=valgrind.supp bin/valgrind/tests/project_schema_test` *(fails: pthread_mutex_destroy with invalid argument)*
- `valgrind --tool=helgrind --quiet --suppressions=valgrind.supp bin/valgrind/tests/labelpriority_test` *(fails: pthread_mutex_destroy with invalid argument)*
- `ctest --test-dir bin/coverage`
- `gcov bin/coverage/mapmaker/CMakeFiles/mapmaker.dir/output.cpp.gcda`


------
https://chatgpt.com/codex/tasks/task_e_6867079568308330ba979bb83aa82633