### PR TITLE
Add coverage tests for breakLines

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,3 +35,8 @@ add_executable(labelpriority_test labelpriority_test.cpp)
 target_link_libraries(labelpriority_test PRIVATE Catch2::Catch2WithMain mapmaker)
 target_compile_features(labelpriority_test PRIVATE cxx_std_17)
 add_test(NAME labelpriority_test COMMAND labelpriority_test)
+
+add_executable(linebreaking_test linebreaking_test.cpp)
+target_link_libraries(linebreaking_test PRIVATE Catch2::Catch2WithMain mapmaker)
+target_compile_features(linebreaking_test PRIVATE cxx_std_17)
+add_test(NAME linebreaking_test COMMAND linebreaking_test)

--- a/tests/linebreaking_test.cpp
+++ b/tests/linebreaking_test.cpp
@@ -1,0 +1,35 @@
+#include <catch2/catch_test_macros.hpp>
+#include "linebreaking.h"
+#include <vector>
+
+TEST_CASE("breakLines handles empty input", "[linebreaking]")
+{
+    std::vector<int> words;
+    std::vector<size_t> breaks;
+    breakLines(words, 10, &breaks);
+    REQUIRE(breaks.empty());
+}
+
+TEST_CASE("breakLines no breaks when line within width", "[linebreaking]")
+{
+    std::vector<int> words = { 1, 2, 3 };
+    std::vector<size_t> breaks;
+    breakLines(words, 10, &breaks);
+    REQUIRE(breaks.empty());
+}
+
+TEST_CASE("breakLines single break", "[linebreaking]")
+{
+    std::vector<int> words = { 4, 5, 6 };
+    std::vector<size_t> breaks;
+    breakLines(words, 10, &breaks);
+    REQUIRE(breaks == std::vector<size_t> { 2 });
+}
+
+TEST_CASE("breakLines multiple breaks", "[linebreaking]")
+{
+    std::vector<int> words = { 3, 5, 6, 4, 5 };
+    std::vector<size_t> breaks;
+    breakLines(words, 10, &breaks);
+    REQUIRE(breaks == std::vector<size_t> { 2, 4 });
+}


### PR DESCRIPTION
## Summary
- add tests for mapmaker's `breakLines` helper
- register the test target in CMake
- confirm 100% branch coverage using gcov

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug`
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/debug -j$(nproc)`
- `cmake --build bin/coverage -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `valgrind --tool=memcheck --quiet --suppressions=valgrind.supp bin/valgrind/tests/hello_test`
- `valgrind --tool=memcheck --quiet --suppressions=valgrind.supp bin/valgrind/tests/textfieldprocessor_test`
- `valgrind --tool=memcheck --quiet --suppressions=valgrind.supp bin/valgrind/tests/tileoutput_test`
- `valgrind --tool=memcheck --quiet --suppressions=valgrind.supp bin/valgrind/tests/project_schema_test`
- `valgrind --tool=memcheck --quiet --suppressions=valgrind.supp bin/valgrind/tests/labelpriority_test`
- `valgrind --tool=memcheck --quiet --suppressions=valgrind.supp bin/valgrind/tests/linebreaking_test`
- `valgrind --tool=helgrind --quiet --suppressions=valgrind.supp bin/valgrind/tests/hello_test`
- `valgrind --tool=helgrind --quiet --suppressions=valgrind.supp bin/valgrind/tests/textfieldprocessor_test`
- `valgrind --tool=helgrind --quiet --suppressions=valgrind.supp bin/valgrind/tests/tileoutput_test`
- `valgrind --tool=helgrind --quiet --suppressions=valgrind.supp bin/valgrind/tests/project_schema_test`
- `valgrind --tool=helgrind --quiet --suppressions=valgrind.supp bin/valgrind/tests/labelpriority_test`
- `valgrind --tool=helgrind --quiet --suppressions=valgrind.supp bin/valgrind/tests/linebreaking_test`
- `ctest --test-dir bin/coverage`
- `gcov -b bin/coverage/mapmaker/CMakeFiles/mapmaker.dir/linebreaking.cpp.gcda`

------
https://chatgpt.com/codex/tasks/task_e_6867083c82b08330ab057efaf8db99f7