### PR TITLE
Add Project XML load/save tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
 
-
 project(tests LANGUAGES CXX)
 
 find_package(Catch2 3 REQUIRED)
@@ -8,7 +7,6 @@ find_package(Catch2 3 REQUIRED)
 add_executable(hello_test hello_test.cpp)
 target_link_libraries(hello_test PRIVATE Catch2::Catch2WithMain mapmaker)
 target_compile_features(hello_test PRIVATE cxx_std_17)
-
 add_test(NAME hello_test COMMAND hello_test)
 
 add_executable(textfieldprocessor_test textfieldprocessor_test.cpp)
@@ -26,10 +24,22 @@ add_executable(project_schema_test
     ../mapmaker/resources.qrc
 )
 set_target_properties(project_schema_test PROPERTIES AUTORCC ON)
-target_link_libraries(project_schema_test PRIVATE Catch2::Catch2WithMain mapmaker Qt5::XmlPatterns)
+target_link_libraries(project_schema_test PRIVATE Catch2::Catch2WithMain mapmaker Qt5::XmlPatterns ZLIB::ZLIB BZip2::BZip2)
+target_link_libraries(project_schema_test PRIVATE EXPAT::EXPAT PROJ::proj SQLiteCpp SQLite::SQLite3 GEOS::geos GEOS::geos_c)
 target_compile_features(project_schema_test PRIVATE cxx_std_17)
 target_compile_definitions(project_schema_test PRIVATE SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 add_test(NAME project_schema_test COMMAND project_schema_test)
+
+add_executable(project_load_save_test
+    project_load_save_test.cpp
+    ../mapmaker/resources.qrc
+)
+set_target_properties(project_load_save_test PROPERTIES AUTORCC ON)
+target_link_libraries(project_load_save_test PRIVATE Catch2::Catch2WithMain mapmaker Qt5::XmlPatterns ZLIB::ZLIB BZip2::BZip2)
+target_link_libraries(project_load_save_test PRIVATE EXPAT::EXPAT PROJ::proj SQLiteCpp SQLite::SQLite3 GEOS::geos GEOS::geos_c)
+target_compile_features(project_load_save_test PRIVATE cxx_std_17)
+target_compile_definitions(project_load_save_test PRIVATE SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+add_test(NAME project_load_save_test COMMAND project_load_save_test)
 
 add_executable(labelpriority_test labelpriority_test.cpp)
 target_link_libraries(labelpriority_test PRIVATE Catch2::Catch2WithMain mapmaker)

--- a/tests/project_load_save_test.cpp
+++ b/tests/project_load_save_test.cpp
@@ -1,0 +1,87 @@
+#include <catch2/catch_test_macros.hpp>
+#include "project.h"
+#include <QXmlSchema>
+#include <QXmlSchemaValidator>
+#include <QFile>
+#include <QTemporaryDir>
+#include <QCoreApplication>
+#include <QNetworkAccessManager>
+#include <QStringList>
+#include <filesystem>
+
+TEST_CASE("Project load/save round trip is XSD valid", "[Project]")
+{
+    int argc = 0;
+    qputenv("QT_PLUGIN_PATH", "");
+    QCoreApplication app(argc, nullptr);
+    QCoreApplication::setLibraryPaths(QStringList());
+    QNetworkAccessManager nam;
+    nam.setNetworkAccessible(QNetworkAccessManager::NotAccessible);
+
+    QXmlSchema schema;
+    QFile xsdFile(":/resources/project.xsd");
+    REQUIRE(xsdFile.open(QIODevice::ReadOnly));
+    schema.load(&xsdFile);
+    REQUIRE(schema.isValid());
+
+    QStringList files = {
+        QStringLiteral(SOURCE_DIR "/projects/groton-sat.osmmap.xml"),
+        QStringLiteral(SOURCE_DIR "/projects/groton-trail.osmmap.xml"),
+        QStringLiteral(SOURCE_DIR "/tests/projects/valid/minimal-file.osmmap.xml"),
+        QStringLiteral(SOURCE_DIR "/tests/projects/valid/direct-download.osmmap.xml"),
+        QStringLiteral(SOURCE_DIR "/tests/projects/valid/extract-download.osmmap.xml")
+    };
+
+    for (const QString& fileName : files) {
+        QFile f(fileName);
+        REQUIRE(f.open(QIODevice::ReadOnly));
+        QXmlSchemaValidator validator(schema);
+        REQUIRE(validator.validate(&f));
+
+        Project project(std::filesystem::path(fileName.toStdString()));
+        QTemporaryDir dir;
+        std::filesystem::path savePath = std::filesystem::path(dir.path().toStdString()) / "out.osmmap.xml";
+        project.save(savePath);
+
+        QFile out(QString::fromStdString(savePath.string()));
+        REQUIRE(out.open(QIODevice::ReadOnly));
+        REQUIRE(validator.validate(&out));
+    }
+
+    schema = QXmlSchema();
+    app.processEvents();
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+}
+
+TEST_CASE("Invalid project XML files fail validation", "[Project]")
+{
+    int argc = 0;
+    qputenv("QT_PLUGIN_PATH", "");
+    QCoreApplication app(argc, nullptr);
+    QCoreApplication::setLibraryPaths(QStringList());
+    QNetworkAccessManager nam;
+    nam.setNetworkAccessible(QNetworkAccessManager::NotAccessible);
+
+    QXmlSchema schema;
+    QFile xsdFile(":/resources/project.xsd");
+    REQUIRE(xsdFile.open(QIODevice::ReadOnly));
+    schema.load(&xsdFile);
+    REQUIRE(schema.isValid());
+
+    QStringList files = {
+        QStringLiteral(SOURCE_DIR "/tests/projects/invalid/missing-map.osmmap.xml"),
+        QStringLiteral(SOURCE_DIR "/tests/projects/invalid/invalid-tileoutput.osmmap.xml"),
+        QStringLiteral(SOURCE_DIR "/tests/projects/invalid/missing-datasource-name.osmmap.xml")
+    };
+
+    for (const QString& fileName : files) {
+        QFile f(fileName);
+        REQUIRE(f.open(QIODevice::ReadOnly));
+        QXmlSchemaValidator validator(schema);
+        REQUIRE_FALSE(validator.validate(&f));
+    }
+
+    schema = QXmlSchema();
+    app.processEvents();
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+}

--- a/tests/projects/invalid/invalid-tileoutput.osmmap.xml
+++ b/tests/projects/invalid/invalid-tileoutput.osmmap.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmmapmakerproject>
+  <openStreetMapFileSource name="Local">
+    <dataSource>Primary</dataSource>
+    <fileName>local.osm</fileName>
+  </openStreetMapFileSource>
+  <tileOutput name="tiles">
+    <minZoom>13</minZoom>
+    <tileSize>256</tileSize>
+    <resolution1x>true</resolution1x>
+    <resolution2x>true</resolution2x>
+    <directory>tiles</directory>
+  </tileOutput>
+  <map backgroundColor="#ffffff" backgroundOpacity="1">
+    <layer dataSource="Primary" k="amenity" type="point">
+      <subLayer>
+        <point>
+          <image>dot</image>
+          <opacity>1</opacity>
+          <color>#000000</color>
+          <width>1</width>
+        </point>
+      </subLayer>
+    </layer>
+  </map>
+</osmmapmakerproject>

--- a/tests/projects/invalid/missing-datasource-name.osmmap.xml
+++ b/tests/projects/invalid/missing-datasource-name.osmmap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmmapmakerproject>
+  <openStreetMapFileSource>
+    <dataSource>Primary</dataSource>
+    <fileName>local.osm</fileName>
+  </openStreetMapFileSource>
+  <tileOutput name="tiles">
+    <maxZoom>18</maxZoom>
+    <minZoom>13</minZoom>
+    <tileSize>256</tileSize>
+    <resolution1x>true</resolution1x>
+    <resolution2x>true</resolution2x>
+    <directory>tiles</directory>
+  </tileOutput>
+  <map backgroundColor="#ffffff" backgroundOpacity="1">
+    <layer dataSource="Primary" k="amenity" type="point">
+      <subLayer>
+        <point>
+          <image>dot</image>
+          <opacity>1</opacity>
+          <color>#000000</color>
+          <width>1</width>
+        </point>
+      </subLayer>
+    </layer>
+  </map>
+</osmmapmakerproject>

--- a/tests/projects/invalid/missing-map.osmmap.xml
+++ b/tests/projects/invalid/missing-map.osmmap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmmapmakerproject>
+  <openStreetMapFileSource name="Local">
+    <dataSource>Primary</dataSource>
+    <fileName>local.osm</fileName>
+  </openStreetMapFileSource>
+  <tileOutput name="tiles">
+    <maxZoom>18</maxZoom>
+    <minZoom>13</minZoom>
+    <tileSize>256</tileSize>
+    <resolution1x>true</resolution1x>
+    <resolution2x>true</resolution2x>
+    <directory>tiles</directory>
+  </tileOutput>
+</osmmapmakerproject>

--- a/tests/projects/valid/direct-download.osmmap.xml
+++ b/tests/projects/valid/direct-download.osmmap.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmmapmakerproject>
+  <openStreetMapDirectDownload name="DD">
+    <dataSource>Primary</dataSource>
+  </openStreetMapDirectDownload>
+  <tileOutput name="tiles">
+    <maxZoom>17</maxZoom>
+    <minZoom>10</minZoom>
+    <tileSize>256</tileSize>
+    <resolution1x>true</resolution1x>
+    <resolution2x>false</resolution2x>
+    <directory>tiles</directory>
+  </tileOutput>
+  <map backgroundColor="#ff0000" backgroundOpacity="0.5">
+    <layer dataSource="Primary" k="highway" type="line">
+      <subLayer>
+        <selector/>
+        <line>
+          <color>#123456</color>
+          <casingColor>#654321</casingColor>
+          <width>1</width>
+          <casingWidth>0</casingWidth>
+          <opacity>1</opacity>
+          <smooth>0</smooth>
+          <dashArray></dashArray>
+        </line>
+      </subLayer>
+    </layer>
+  </map>
+</osmmapmakerproject>

--- a/tests/projects/valid/extract-download.osmmap.xml
+++ b/tests/projects/valid/extract-download.osmmap.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmmapmakerproject>
+  <openStreetMapExtractDownload name="EX">
+    <dataSource>Primary</dataSource>
+  </openStreetMapExtractDownload>
+  <tileOutput name="tiles">
+    <maxZoom>16</maxZoom>
+    <minZoom>12</minZoom>
+    <tileSize>512</tileSize>
+    <resolution1x>false</resolution1x>
+    <resolution2x>true</resolution2x>
+    <directory>tiles</directory>
+  </tileOutput>
+  <map backgroundColor="#0000ff" backgroundOpacity="0.8">
+    <layer dataSource="Primary" k="building" type="area">
+      <subLayer>
+        <selector/>
+        <area>
+          <color>#aaaaaa</color>
+          <opacity>1</opacity>
+          <casingWidth>0</casingWidth>
+          <casingColor>#000000</casingColor>
+          <fillImage></fillImage>
+          <fillImageOpacity>1</fillImageOpacity>
+        </area>
+      </subLayer>
+    </layer>
+  </map>
+</osmmapmakerproject>

--- a/tests/projects/valid/minimal-file.osmmap.xml
+++ b/tests/projects/valid/minimal-file.osmmap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmmapmakerproject>
+  <openStreetMapFileSource name="Local">
+    <dataSource>Primary</dataSource>
+    <fileName>local.osm</fileName>
+  </openStreetMapFileSource>
+  <tileOutput name="tiles">
+    <maxZoom>18</maxZoom>
+    <minZoom>13</minZoom>
+    <tileSize>256</tileSize>
+    <resolution1x>true</resolution1x>
+    <resolution2x>true</resolution2x>
+    <directory>tiles</directory>
+  </tileOutput>
+  <map backgroundColor="#ffffff" backgroundOpacity="1">
+    <layer dataSource="Primary" k="amenity" type="point">
+      <subLayer>
+        <selector/>
+        <point>
+          <image>dot</image>
+          <opacity>1</opacity>
+          <color>#000000</color>
+          <width>1</width>
+        </point>
+      </subLayer>
+    </layer>
+  </map>
+</osmmapmakerproject>


### PR DESCRIPTION
## Summary
- add new project XML load/save tests
- include assorted valid and invalid project XML examples
- link extra libraries for project tests

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug`
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release` *(fails: project_load_save_test)*

------
https://chatgpt.com/codex/tasks/task_e_686708d838288330b1bb9c125f758dbf