### PR TITLE
Add Project XML round trip tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,3 +35,26 @@ add_executable(labelpriority_test labelpriority_test.cpp)
 target_link_libraries(labelpriority_test PRIVATE Catch2::Catch2WithMain mapmaker)
 target_compile_features(labelpriority_test PRIVATE cxx_std_17)
 add_test(NAME labelpriority_test COMMAND labelpriority_test)
+
+add_executable(project_load_save_test
+    project_load_save_test.cpp
+    ../mapmaker/resources.qrc
+    ../osmmapmakerapp/resources.qrc
+)
+set_target_properties(project_load_save_test PROPERTIES AUTORCC ON)
+target_link_libraries(project_load_save_test PRIVATE
+    Catch2::Catch2WithMain
+    mapmaker
+    Qt5::XmlPatterns
+    BZip2::BZip2
+    ZLIB::ZLIB
+    EXPAT::EXPAT
+    PROJ::proj
+    SQLiteCpp
+    SQLite::SQLite3
+    GEOS::geos
+    GEOS::geos_c
+)
+target_compile_features(project_load_save_test PRIVATE cxx_std_17)
+target_compile_definitions(project_load_save_test PRIVATE SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+add_test(NAME project_load_save_test COMMAND project_load_save_test)

--- a/tests/project_load_save_test.cpp
+++ b/tests/project_load_save_test.cpp
@@ -1,0 +1,97 @@
+#include <catch2/catch_test_macros.hpp>
+#include <QCoreApplication>
+#include <QXmlSchema>
+#include <QXmlSchemaValidator>
+#include <QFile>
+#include <QNetworkAccessManager>
+#include <QEvent>
+#include <QStringList>
+#include "project.h"
+#include <filesystem>
+
+TEST_CASE("Valid project files load and save", "[Project]")
+{
+    int argc = 0;
+    qputenv("QT_PLUGIN_PATH", "");
+    QCoreApplication app(argc, nullptr);
+    QCoreApplication::setLibraryPaths(QStringList());
+    QNetworkAccessManager nam;
+    nam.setNetworkAccessible(QNetworkAccessManager::NotAccessible);
+
+    QXmlSchema schema;
+    QFile xsdFile(":/resources/project.xsd");
+    REQUIRE(xsdFile.open(QIODevice::ReadOnly));
+    schema.load(&xsdFile);
+    REQUIRE(schema.isValid());
+
+    QStringList files = {
+        QStringLiteral(SOURCE_DIR "/projects/groton-sat.osmmap.xml"),
+        QStringLiteral(SOURCE_DIR "/projects/groton-trail.osmmap.xml"),
+        QStringLiteral(SOURCE_DIR "/tests/project_xml_samples/valid/valid_line.osmmap.xml"),
+        QStringLiteral(SOURCE_DIR "/tests/project_xml_samples/valid/valid_point.osmmap.xml"),
+        QStringLiteral(SOURCE_DIR "/tests/project_xml_samples/valid/valid_area.osmmap.xml")
+    };
+
+    for (const QString& fileName : files) {
+        QFile src(fileName);
+        REQUIRE(src.open(QIODevice::ReadOnly));
+        QXmlSchemaValidator validator(schema);
+        REQUIRE(validator.validate(&src));
+        src.close();
+
+        std::filesystem::path p = fileName.toStdString();
+        {
+            Project proj(p);
+            for (auto* ds : proj.dataSources()) {
+                ds->setImportTime(QDateTime::currentDateTimeUtc());
+            }
+            std::filesystem::path tmp = p.parent_path() / "tmp_saved.osmmap.xml";
+            proj.save(tmp);
+            QFile out(QString::fromStdString(tmp.string()));
+            REQUIRE(out.open(QIODevice::ReadOnly));
+            REQUIRE(validator.validate(&out));
+            out.close();
+            QFile::remove(QString::fromStdString(tmp.string()));
+        }
+        std::filesystem::remove_all(p.replace_extension(""));
+    }
+
+    schema = QXmlSchema();
+    app.processEvents();
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+}
+
+TEST_CASE("Invalid project files fail validation", "[Project]")
+{
+    int argc = 0;
+    qputenv("QT_PLUGIN_PATH", "");
+    QCoreApplication app(argc, nullptr);
+    QCoreApplication::setLibraryPaths(QStringList());
+    QNetworkAccessManager nam;
+    nam.setNetworkAccessible(QNetworkAccessManager::NotAccessible);
+
+    QXmlSchema schema;
+    QFile xsdFile(":/resources/project.xsd");
+    REQUIRE(xsdFile.open(QIODevice::ReadOnly));
+    schema.load(&xsdFile);
+    REQUIRE(schema.isValid());
+
+    QStringList files = {
+        QStringLiteral(SOURCE_DIR "/tests/project_xml_samples/invalid/invalid_no_map.osmmap.xml"),
+        QStringLiteral(SOURCE_DIR "/tests/project_xml_samples/invalid/invalid_bad_root.osmmap.xml"),
+        QStringLiteral(SOURCE_DIR "/tests/project_xml_samples/invalid/invalid_missing_layer_attribute.osmmap.xml"),
+        QStringLiteral(SOURCE_DIR "/tests/project_xml_samples/invalid/invalid_bad_tileoutput_boolean.osmmap.xml"),
+        QStringLiteral(SOURCE_DIR "/tests/project_xml_samples/invalid/invalid_two_geometry_tags.osmmap.xml")
+    };
+
+    for (const QString& fileName : files) {
+        QFile f(fileName);
+        REQUIRE(f.open(QIODevice::ReadOnly));
+        QXmlSchemaValidator validator(schema);
+        REQUIRE_FALSE(validator.validate(&f));
+    }
+
+    schema = QXmlSchema();
+    app.processEvents();
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+}

--- a/tests/project_xml_samples/invalid/invalid_bad_root.osmmap.xml
+++ b/tests/project_xml_samples/invalid/invalid_bad_root.osmmap.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wrongroot></wrongroot>

--- a/tests/project_xml_samples/invalid/invalid_bad_tileoutput_boolean.osmmap.xml
+++ b/tests/project_xml_samples/invalid/invalid_bad_tileoutput_boolean.osmmap.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmmapmakerproject>
+ <tileOutput name="bad">
+  <maxZoom>1</maxZoom>
+  <minZoom>0</minZoom>
+  <tileSize>256</tileSize>
+  <resolution1x>yes</resolution1x>
+  <resolution2x>false</resolution2x>
+  <directory></directory>
+ </tileOutput>
+ <map>
+  <layer dataSource="Primary" k="x" type="line">
+   <subLayer name="a" visible="true">
+    <line>
+     <color>#000</color>
+     <casingColor>#fff</casingColor>
+     <width>1</width>
+     <casingWidth>0</casingWidth>
+     <opacity>1</opacity>
+     <smooth>0</smooth>
+     <dashArray></dashArray>
+    </line>
+   </subLayer>
+  </layer>
+ </map>
+</osmmapmakerproject>

--- a/tests/project_xml_samples/invalid/invalid_missing_layer_attribute.osmmap.xml
+++ b/tests/project_xml_samples/invalid/invalid_missing_layer_attribute.osmmap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmmapmakerproject>
+ <map>
+  <layer dataSource="Primary" type="line">
+   <subLayer name="a" visible="true">
+    <line>
+     <color>#000</color>
+     <casingColor>#fff</casingColor>
+     <width>1</width>
+     <casingWidth>0</casingWidth>
+     <opacity>1</opacity>
+     <smooth>0</smooth>
+     <dashArray></dashArray>
+    </line>
+   </subLayer>
+  </layer>
+ </map>
+</osmmapmakerproject>

--- a/tests/project_xml_samples/invalid/invalid_no_map.osmmap.xml
+++ b/tests/project_xml_samples/invalid/invalid_no_map.osmmap.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmmapmakerproject>
+ <tileOutput name="invalid">
+  <maxZoom>1</maxZoom>
+  <minZoom>0</minZoom>
+  <tileSize>256</tileSize>
+  <resolution1x>true</resolution1x>
+  <resolution2x>true</resolution2x>
+  <directory></directory>
+ </tileOutput>
+</osmmapmakerproject>

--- a/tests/project_xml_samples/invalid/invalid_two_geometry_tags.osmmap.xml
+++ b/tests/project_xml_samples/invalid/invalid_two_geometry_tags.osmmap.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmmapmakerproject>
+ <map>
+  <layer dataSource="Primary" k="amenity" type="point">
+   <subLayer name="s" visible="true">
+    <point>
+     <image>i.png</image>
+     <opacity>1</opacity>
+     <color>#fff</color>
+     <width>1</width>
+    </point>
+    <line>
+     <color>#000</color>
+     <casingColor>#fff</casingColor>
+     <width>1</width>
+     <casingWidth>0</casingWidth>
+     <opacity>1</opacity>
+     <smooth>0</smooth>
+     <dashArray></dashArray>
+    </line>
+   </subLayer>
+  </layer>
+ </map>
+</osmmapmakerproject>

--- a/tests/project_xml_samples/valid/valid_area.osmmap.xml
+++ b/tests/project_xml_samples/valid/valid_area.osmmap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmmapmakerproject>
+ <openStreetMapDirectDownload name="remote">
+  <dataSource>Primary</dataSource>
+ </openStreetMapDirectDownload>
+ <openStreetMapExtractDownload name="remote2">
+  <dataSource>Secondary</dataSource>
+ </openStreetMapExtractDownload>
+ <map backgroundColor="#00ff00" backgroundOpacity="0.5">
+  <layer dataSource="Primary" k="landuse" type="area">
+   <subLayer name="forest" visible="true" minZoom="13">
+    <selector>
+     <condition key="landuse">
+      <value>forest</value>
+     </condition>
+    </selector>
+    <area>
+     <color>#00ff00</color>
+     <opacity>1</opacity>
+     <casingWidth>0</casingWidth>
+     <casingColor>#000000</casingColor>
+     <fillImage></fillImage>
+     <fillImageOpacity>1</fillImageOpacity>
+    </area>
+   </subLayer>
+  </layer>
+ </map>
+</osmmapmakerproject>

--- a/tests/project_xml_samples/valid/valid_line.osmmap.xml
+++ b/tests/project_xml_samples/valid/valid_line.osmmap.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmmapmakerproject>
+ <tileOutput name="lineTiles">
+  <maxZoom>12</maxZoom>
+  <minZoom>10</minZoom>
+  <tileSize>256</tileSize>
+  <resolution1x>true</resolution1x>
+  <resolution2x>true</resolution2x>
+  <directory></directory>
+ </tileOutput>
+ <map backgroundColor="#ffffff" backgroundOpacity="1">
+  <layer dataSource="Primary" k="highway" type="line">
+   <subLayer name="roads" visible="true" minZoom="10">
+    <selector>
+     <condition key="highway">
+      <value>residential</value>
+     </condition>
+    </selector>
+    <line>
+     <color>#000000</color>
+     <casingColor>#ffffff</casingColor>
+     <width>1</width>
+     <casingWidth>1</casingWidth>
+     <opacity>1</opacity>
+     <smooth>0</smooth>
+     <dashArray></dashArray>
+    </line>
+    <label minZoom="12">
+     <text>[name]</text>
+     <height>12</height>
+     <weight>700</weight>
+     <color>#000000</color>
+     <haloSize>1</haloSize>
+     <haloColor>#ffffff</haloColor>
+     <maxWrapWidth>100</maxWrapWidth>
+     <offsetY>0</offsetY>
+     <priority>1</priority>
+    </label>
+   </subLayer>
+  </layer>
+ </map>
+</osmmapmakerproject>

--- a/tests/project_xml_samples/valid/valid_point.osmmap.xml
+++ b/tests/project_xml_samples/valid/valid_point.osmmap.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmmapmakerproject>
+ <openStreetMapFileSource name="local">
+  <dataSource>Primary</dataSource>
+  <fileName>data.osm</fileName>
+ </openStreetMapFileSource>
+ <tileOutput name="pointTiles">
+  <maxZoom>18</maxZoom>
+  <minZoom>15</minZoom>
+  <tileSize>256</tileSize>
+  <resolution1x>true</resolution1x>
+  <resolution2x>false</resolution2x>
+  <directory></directory>
+ </tileOutput>
+ <map>
+  <layer dataSource="Primary" k="amenity" type="point">
+   <subLayer name="poi" visible="true" minZoom="15">
+    <selector>
+     <condition key="amenity">
+      <value>restaurant</value>
+     </condition>
+    </selector>
+    <point>
+     <image>poi.png</image>
+     <opacity>1</opacity>
+     <color>#ff0000</color>
+     <width>1</width>
+    </point>
+   </subLayer>
+  </layer>
+ </map>
+</osmmapmakerproject>


### PR DESCRIPTION
## Summary
- extend test suite with Project XML load/save coverage
- add CMake target for new tests with Qt resources
- provide valid and invalid project XML samples

## Testing
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/debug -j$(nproc)`
- `cmake --build bin/coverage -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/valgrind`
- `valgrind --tool=memcheck --suppressions=valgrind.supp bin/valgrind/tests/hello_test`
- `valgrind --tool=memcheck --suppressions=valgrind.supp bin/valgrind/tests/textfieldprocessor_test`
- `valgrind --tool=memcheck --suppressions=valgrind.supp bin/valgrind/tests/tileoutput_test`
- `valgrind --tool=memcheck --suppressions=valgrind.supp bin/valgrind/tests/project_schema_test`
- `valgrind --tool=memcheck --suppressions=valgrind.supp bin/valgrind/tests/labelpriority_test`
- `valgrind --tool=memcheck --suppressions=valgrind.supp bin/valgrind/tests/project_load_save_test`
- `valgrind --tool=helgrind --suppressions=valgrind.supp bin/valgrind/tests/hello_test`
- `valgrind --tool=helgrind --suppressions=valgrind.supp bin/valgrind/tests/textfieldprocessor_test`
- `valgrind --tool=helgrind --suppressions=valgrind.supp bin/valgrind/tests/tileoutput_test`
- `valgrind --tool=helgrind --suppressions=valgrind.supp bin/valgrind/tests/project_schema_test`
- `valgrind --tool=helgrind --suppressions=valgrind.supp bin/valgrind/tests/labelpriority_test`
- `valgrind --tool=helgrind --suppressions=valgrind.supp bin/valgrind/tests/project_load_save_test`

------
https://chatgpt.com/codex/tasks/task_e_686708d838288330b1bb9c125f758dbf