### PR TITLE
Add new style layer tests and update coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,12 @@
   3. Execute `ctest --output-on-failure --test-dir bin/release` (or `--test-dir bin/valgrind`) and make sure every test succeeds.
   4. Run each test binary in `bin/valgrind` under both `valgrind --tool=memcheck` and `valgrind --tool=helgrind` using the `valgrind.supp` suppression file. No tests should detect `RUNNING_ON_VALGRIND` or be skipped when running under valgrind, and all errors must be investigated.
   5. Update `valgrind.supp` if recurring leaks from third-party libraries are discovered so that future runs flag only new problems.
+  - Current unit test executables include:
+    `hello_test`, `textfieldprocessor_test`, `tileoutput_test`,
+    `project_schema_test`, `labelpriority_test`, `stylelayer_test`,
+    `style_selector_test`, `sublayer_test`, `point_test`, `line_test`,
+    `area_test`, `label_test`, `osmdata_test`, `linebreaking_test`,
+    `project_load_save_test`.
 
 - Clean builds by removing the `bin` directory.
 - Run `clang-format -i` on all modified C/C++ files before committing.

--- a/tests/coverage_report.txt
+++ b/tests/coverage_report.txt
@@ -1,4 +1,16 @@
-output.cpp           |34.3%     70| 0.0%    18|    -      0
-stylelayer.cpp       |18.6%    253| 0.0%    22|    -      0
-textfield.cpp        | 5.0%     40| 0.0%     2|    -      0
-               Total:|20.1%    363| 0.0%    42|    -      0
+========================================================================
+========================================================================
+[/workspace/osmmapmaker/mapmaker/]
+Filename                          |Rate     Num|Rate    Num|Rate     Num
+project.h                         | 100%      2| 0.0%     1|    -      0
+output.cpp                        |27.6%     87| 0.0%    23|    -      0
+osmdata.cpp                       | 8.7%    161| 0.0%    12|    -      0
+project.cpp                       |18.8%    138| 0.0%     9|    -      0
+textfield.cpp                     | 4.5%     44| 0.0%     2|    -      0
+stylelayer.cpp                    | 8.9%    528| 0.0%    45|    -      0
+datasource.cpp                    |31.9%     47| 0.0%    10|    -      0
+osmdatafile.cpp                   |33.3%     24| 0.0%     8|    -      0
+linebreaking.cpp                  |11.1%      9| 0.0%     1|    -      0
+osmdataextractdownload.cpp        |50.0%     10| 0.0%     4|    -      0
+                                  |Lines       |Functions  |Branches    
+                            Total:|13.7%   1050| 0.0%   115|    -      0

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -78,7 +78,6 @@
    ...
    obj:/usr/lib/x86_64-linux-gnu/libQt5*
 }
-
 {
    QtHelgrindPthreadDestroyNetwork
    Helgrind:Race


### PR DESCRIPTION
## Summary
- list new unit tests in AGENTS instructions
- regenerate coverage report
- tidy valgrind suppression file

## Testing
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/coverage`
- `valgrind --tool=memcheck --suppressions=valgrind.supp bin/valgrind/tests/area_test`

------
https://chatgpt.com/codex/tasks/task_e_686712ae376083309845f43d22c24ab2