### PR TITLE
Add tests for XML load errors

### DIFF
--- a/mapmaker/CMakeLists.txt
+++ b/mapmaker/CMakeLists.txt
@@ -32,5 +32,6 @@ target_link_libraries(mapmaker
     PUBLIC
         Qt5::Widgets
         Qt5::Xml
+        Qt5::XmlPatterns
 )
 

--- a/mapmaker/resources/project.xsd
+++ b/mapmaker/resources/project.xsd
@@ -1,6 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
 
+  <!-- Common numeric types used throughout the project schema -->
+  <xs:simpleType name="nonNegativeInt">
+    <xs:restriction base="xs:nonNegativeInteger"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="positiveInt">
+    <xs:restriction base="xs:positiveInteger"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="nonNegativeDecimal">
+    <xs:restriction base="xs:decimal">
+      <xs:minInclusive value="0"/>
+    </xs:restriction>
+  </xs:simpleType>
+
   <xs:element name="osmmapmakerproject">
     <xs:complexType>
       <xs:sequence>
@@ -18,7 +33,7 @@
       <xs:sequence>
         <xs:element name="dataSource" type="xs:string"/>
         <xs:element name="lastUpdateDate" type="xs:dateTime" minOccurs="0"/>
-        <xs:element name="importDurationS" type="xs:int" minOccurs="0"/>
+        <xs:element name="importDurationS" type="nonNegativeInt" minOccurs="0"/>
         <xs:element name="fileName" type="xs:string"/>
       </xs:sequence>
       <xs:attribute name="name" type="xs:string" use="required"/>
@@ -30,7 +45,7 @@
       <xs:sequence>
         <xs:element name="dataSource" type="xs:string"/>
         <xs:element name="lastUpdateDate" type="xs:dateTime" minOccurs="0"/>
-        <xs:element name="importDurationS" type="xs:int" minOccurs="0"/>
+        <xs:element name="importDurationS" type="nonNegativeInt" minOccurs="0"/>
       </xs:sequence>
       <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>
@@ -41,7 +56,7 @@
       <xs:sequence>
         <xs:element name="dataSource" type="xs:string"/>
         <xs:element name="lastUpdateDate" type="xs:dateTime" minOccurs="0"/>
-        <xs:element name="importDurationS" type="xs:int" minOccurs="0"/>
+        <xs:element name="importDurationS" type="nonNegativeInt" minOccurs="0"/>
       </xs:sequence>
       <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>
@@ -50,9 +65,9 @@
   <xs:element name="tileOutput">
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="maxZoom" type="xs:int"/>
-        <xs:element name="minZoom" type="xs:int"/>
-        <xs:element name="tileSize" type="xs:int"/>
+        <xs:element name="maxZoom" type="nonNegativeInt"/>
+        <xs:element name="minZoom" type="nonNegativeInt"/>
+        <xs:element name="tileSize" type="positiveInt"/>
         <xs:element name="resolution1x" type="xs:boolean"/>
         <xs:element name="resolution2x" type="xs:boolean"/>
         <xs:element name="directory" type="xs:string"/>
@@ -67,7 +82,7 @@
         <xs:element ref="layer" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
       <xs:attribute name="backgroundColor" type="xs:string" use="optional"/>
-      <xs:attribute name="backgroundOpacity" type="xs:decimal" use="optional"/>
+      <xs:attribute name="backgroundOpacity" type="nonNegativeDecimal" use="optional"/>
     </xs:complexType>
   </xs:element>
 
@@ -100,7 +115,7 @@
             </xs:sequence>
             <xs:attribute name="name" type="xs:string" use="optional"/>
             <xs:attribute name="visible" type="xs:boolean" use="optional"/>
-            <xs:attribute name="minZoom" type="xs:int" use="optional"/>
+            <xs:attribute name="minZoom" type="nonNegativeInt" use="optional"/>
           </xs:complexType>
         </xs:element>
       </xs:sequence>
@@ -122,10 +137,10 @@
     <xs:sequence>
       <xs:element name="color" type="xs:string"/>
       <xs:element name="casingColor" type="xs:string"/>
-      <xs:element name="width" type="xs:decimal"/>
-      <xs:element name="casingWidth" type="xs:decimal"/>
-      <xs:element name="opacity" type="xs:decimal"/>
-      <xs:element name="smooth" type="xs:decimal"/>
+      <xs:element name="width" type="nonNegativeDecimal"/>
+      <xs:element name="casingWidth" type="nonNegativeDecimal"/>
+      <xs:element name="opacity" type="nonNegativeDecimal"/>
+      <xs:element name="smooth" type="nonNegativeDecimal"/>
       <xs:element name="dashArray" type="xs:string"/>
     </xs:sequence>
   </xs:complexType>
@@ -133,37 +148,37 @@
   <xs:complexType name="PointType">
     <xs:sequence>
       <xs:element name="image" type="xs:string"/>
-      <xs:element name="opacity" type="xs:decimal"/>
+      <xs:element name="opacity" type="nonNegativeDecimal"/>
       <xs:element name="color" type="xs:string"/>
-      <xs:element name="width" type="xs:decimal"/>
+      <xs:element name="width" type="nonNegativeDecimal"/>
     </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="AreaType">
     <xs:sequence>
       <xs:element name="color" type="xs:string"/>
-      <xs:element name="opacity" type="xs:decimal"/>
-      <xs:element name="casingWidth" type="xs:decimal"/>
+      <xs:element name="opacity" type="nonNegativeDecimal"/>
+      <xs:element name="casingWidth" type="nonNegativeDecimal"/>
       <xs:element name="casingColor" type="xs:string"/>
       <xs:element name="fillImage" type="xs:string"/>
-      <xs:element name="fillImageOpacity" type="xs:decimal"/>
+      <xs:element name="fillImageOpacity" type="nonNegativeDecimal"/>
     </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="LabelType">
     <xs:sequence>
       <xs:element name="text" type="xs:string"/>
-      <xs:element name="height" type="xs:decimal"/>
-      <xs:element name="weight" type="xs:decimal"/>
+      <xs:element name="height" type="nonNegativeDecimal"/>
+      <xs:element name="weight" type="nonNegativeDecimal"/>
       <xs:element name="color" type="xs:string"/>
-      <xs:element name="haloSize" type="xs:decimal"/>
+      <xs:element name="haloSize" type="nonNegativeDecimal"/>
       <xs:element name="haloColor" type="xs:string"/>
-      <xs:element name="lineLaxSpacing" type="xs:decimal" minOccurs="0"/>
-      <xs:element name="maxWrapWidth" type="xs:decimal"/>
+      <xs:element name="lineLaxSpacing" type="nonNegativeDecimal" minOccurs="0"/>
+      <xs:element name="maxWrapWidth" type="nonNegativeDecimal"/>
       <xs:element name="offsetY" type="xs:decimal"/>
-      <xs:element name="priority" type="xs:int"/>
+      <xs:element name="priority" type="nonNegativeInt"/>
     </xs:sequence>
-    <xs:attribute name="minZoom" type="xs:int" use="optional"/>
+    <xs:attribute name="minZoom" type="nonNegativeInt" use="optional"/>
   </xs:complexType>
 
 </xs:schema>

--- a/tests/coverage_report.txt
+++ b/tests/coverage_report.txt
@@ -5,7 +5,7 @@ Filename                          |Rate     Num|Rate    Num|Rate     Num
 project.h                         | 100%      2| 0.0%     1|    -      0
 output.cpp                        |27.6%     87| 0.0%    23|    -      0
 osmdata.cpp                       | 8.7%    161| 0.0%    12|    -      0
-project.cpp                       |18.8%    138| 0.0%     9|    -      0
+project.cpp                       |17.9%    168| 0.0%    13|    -      0
 textfield.cpp                     | 4.5%     44| 0.0%     2|    -      0
 stylelayer.cpp                    | 8.9%    507| 0.0%    43|    -      0
 datasource.cpp                    |31.9%     47| 0.0%    10|    -      0
@@ -13,4 +13,4 @@ osmdatafile.cpp                   |33.3%     24| 0.0%     8|    -      0
 linebreaking.cpp                  |11.1%      9| 0.0%     1|    -      0
 osmdataextractdownload.cpp        |50.0%     10| 0.0%     4|    -      0
                                   |Lines       |Functions  |Branches    
-                            Total:|13.8%   1029| 0.0%   113|    -      0
+                            Total:|13.8%   1059| 0.0%   117|    -      0

--- a/tests/project_xml_samples/invalid/invalid_negative_zoom.osmmap.xml
+++ b/tests/project_xml_samples/invalid/invalid_negative_zoom.osmmap.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmmapmakerproject>
+ <tileOutput name="negZoom">
+  <maxZoom>-1</maxZoom>
+  <minZoom>0</minZoom>
+  <tileSize>256</tileSize>
+  <resolution1x>true</resolution1x>
+  <resolution2x>true</resolution2x>
+  <directory></directory>
+ </tileOutput>
+ <map>
+  <layer dataSource="Primary" k="amenity" type="point">
+   <subLayer>
+    <point>
+     <image>i.png</image>
+     <opacity>1</opacity>
+     <color>#fff</color>
+     <width>1</width>
+    </point>
+   </subLayer>
+  </layer>
+ </map>
+</osmmapmakerproject>

--- a/tests/project_xml_samples/malformed/malformed_missing_lt.osmmap.xml
+++ b/tests/project_xml_samples/malformed/malformed_missing_lt.osmmap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmmapmakerproject>
+ <map>
+  layer></layer>
+ </map>
+</osmmapmakerproject>


### PR DESCRIPTION
## Summary
- add new invalid XML examples for negative zoom and malformed structure
- test Project constructor throws with filename and line number for invalid XML
- test malformed XML reports parse location correctly
- update coverage report

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug`
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/debug -j$(nproc)`
- `cmake --build bin/coverage -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/coverage`
- `valgrind --tool=memcheck --quiet --suppressions=valgrind.supp bin/valgrind/tests/project_load_save_test`
- `valgrind --tool=helgrind --quiet --suppressions=valgrind.supp bin/valgrind/tests/project_load_save_test`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_6867209667508330bc6530504de4bc8d