### PR TITLE
Fix TileCache inheritance bug

### DIFF
--- a/mapmaker/tilecache.cpp
+++ b/mapmaker/tilecache.cpp
@@ -1,1 +1,7 @@
-#include <tilecache.h>
+#include "tilecache.h"
+
+TileCache::TileCache() { }
+
+TileCache::~TileCache() { }
+
+bool TileCache::GetTile(double, int, int, uint, QPixmap*) { return false; }

--- a/mapmaker/tilecache.h
+++ b/mapmaker/tilecache.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <QObject>
 #include <QPixmap>
 
 /// Simple cache for rendered map tiles.
-class TileCache : QObject {
+class TileCache : public QObject {
     Q_OBJECT
 
 public:

--- a/tests/coverage_report.txt
+++ b/tests/coverage_report.txt
@@ -13,4 +13,4 @@ osmdatafile.cpp                   |33.3%     24| 0.0%     8|    -      0
 linebreaking.cpp                  |11.1%      9| 0.0%     1|    -      0
 osmdataextractdownload.cpp        |50.0%     10| 0.0%     4|    -      0
                                   |Lines       |Functions  |Branches    
-                            Total:|13.8%   1059| 0.0%   117|    -      0
+                            Total:|13.5%   1079| 0.0%   118|    -      0


### PR DESCRIPTION
## Summary
- fix TileCache to inherit publicly from QObject
- add stub TileCache implementation
- update coverage report

## Testing
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/debug -j$(nproc)`
- `cmake --build bin/coverage -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `for test in ...; do valgrind --tool=memcheck ... ; done`
- `for test in ...; do valgrind --tool=helgrind ... ; done`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_68672c5c4d9c83308f736e14a605713a