### PR TITLE
Fix StyleSelector default selector bug

### DIFF
--- a/mapmaker/stylelayer.cpp
+++ b/mapmaker/stylelayer.cpp
@@ -9,7 +9,7 @@ StyleSelector::StyleSelector()
 StyleSelector::StyleSelector(const QString& key)
 {
     keys_.push_back(key);
-    values_.push_back(std::vector<QString>() = { QString("*") });
+    values_.push_back(std::vector<QString> { QString("*") });
 
     keysStd_.push_back(key.toStdString());
     std::vector<std::string> valuesStd;

--- a/tests/coverage_report.txt
+++ b/tests/coverage_report.txt
@@ -7,10 +7,10 @@ output.cpp                        |27.6%     87| 0.0%    23|    -      0
 osmdata.cpp                       | 8.7%    161| 0.0%    12|    -      0
 project.cpp                       |16.1%    186| 0.0%    16|    -      0
 textfield.cpp                     | 4.5%     44| 0.0%     2|    -      0
-stylelayer.cpp                    | 8.5%    527| 0.0%    44|    -      0
+stylelayer.cpp                    | 8.7%    530| 0.0%    45|    -      0
 datasource.cpp                    |27.8%     54| 0.0%    11|    -      0
 osmdatafile.cpp                   |33.3%     24| 0.0%     8|    -      0
 linebreaking.cpp                  |11.1%      9| 0.0%     1|    -      0
 osmdataextractdownload.cpp        |50.0%     10| 0.0%     4|    -      0
                                   |Lines       |Functions  |Branches    
-                            Total:|13.2%   1104| 0.0%   122|    -      0
+                            Total:|13.3%   1107| 0.0%   123|    -      0


### PR DESCRIPTION
## Summary
- fix default StyleSelector construction so the wildcard selector is initialized correctly
- regenerate coverage report

## Testing
- `cmake --build bin/release -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/release`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/valgrind`
- `cmake --build bin/coverage -j$(nproc)`
- `ctest --output-on-failure --test-dir bin/coverage`

------
https://chatgpt.com/codex/tasks/task_e_686731730da08330823429de6c8e87e2