### PR TITLE
Clean up TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -39,25 +39,6 @@ used to shorten labels when rendering maps.
 - Add unit tests that load a project with multiple abbreviation sets.
 - Verify labels using `abbrevSet` render the expected text.
 
-## Word-based Line Wrapping
-### Goal
-Allow label text to break at word boundaries instead of arbitrary character
-positions so that multi line labels remain legible on narrow features.
-
-### Specification
-1. Add an optional `wordWrap="true"` attribute on `<label>` elements.
-2. When enabled, determine the maximum line width using the label's bounding
-   box and font metrics.
-3. Use `QTextBoundaryFinder` to iterate over Unicode word breaks and build lines
-   that fit within the width.  Hyphenate only when a single word exceeds the
-   width.
-4. Update `RenderQT` and `TextFieldProcessor` to respect the new attribute.
-5. Create unit tests verifying wrapped output for long road names and points of
-   interest.
-
-### Automated Testing
-- Render labels at small widths with and without `wordWrap` enabled.
-- Confirm breaks occur at word boundaries and long words hyphenate.
 
 ## Additional Marker Types for Points
 ### Goal

--- a/tests/coverage_report.txt
+++ b/tests/coverage_report.txt
@@ -7,10 +7,10 @@ output.cpp                        |27.6%     87| 0.0%    23|    -      0
 osmdata.cpp                       | 8.7%    161| 0.0%    12|    -      0
 project.cpp                       |16.1%    186| 0.0%    16|    -      0
 textfield.cpp                     | 4.5%     44| 0.0%     2|    -      0
-stylelayer.cpp                    | 8.5%    527| 0.0%    44|    -      0
+stylelayer.cpp                    | 8.7%    530| 0.0%    45|    -      0
 datasource.cpp                    |27.8%     54| 0.0%    11|    -      0
 osmdatafile.cpp                   |33.3%     24| 0.0%     8|    -      0
 linebreaking.cpp                  |11.1%      9| 0.0%     1|    -      0
 osmdataextractdownload.cpp        |50.0%     10| 0.0%     4|    -      0
                                   |Lines       |Functions  |Branches    
-                            Total:|13.2%   1104| 0.0%   122|    -      0
+                            Total:|13.3%   1107| 0.0%   123|    -      0


### PR DESCRIPTION
## Summary
- remove obsolete Word-based Line Wrapping entry from `TODO.md`
- update coverage report

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake --build bin/release -j$(nproc)`
- `ctest --test-dir bin/release`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake --build bin/coverage -j$(nproc)`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_68672c262ca88330a98c234e1c776156