### PR TITLE
Add additional tests and update coverage

### DIFF
--- a/tests/coverage_report.txt
+++ b/tests/coverage_report.txt
@@ -7,10 +7,10 @@ output.cpp                        |27.6%     87| 0.0%    23|    -      0
 osmdata.cpp                       | 8.7%    161| 0.0%    12|    -      0
 project.cpp                       |16.1%    186| 0.0%    16|    -      0
 textfield.cpp                     | 4.5%     44| 0.0%     2|    -      0
-stylelayer.cpp                    | 8.5%    527| 0.0%    44|    -      0
-datasource.cpp                    |27.8%     54| 0.0%    11|    -      0
+stylelayer.cpp                    | 8.7%    530| 0.0%    45|    -      0
+datasource.cpp                    |25.0%     60| 0.0%    14|    -      0
 osmdatafile.cpp                   |33.3%     24| 0.0%     8|    -      0
 linebreaking.cpp                  |11.1%      9| 0.0%     1|    -      0
 osmdataextractdownload.cpp        |50.0%     10| 0.0%     4|    -      0
                                   |Lines       |Functions  |Branches    
-                            Total:|13.2%   1104| 0.0%   122|    -      0
+                            Total:|13.2%   1113| 0.0%   126|    -      0

--- a/tests/osmdata_test.cpp
+++ b/tests/osmdata_test.cpp
@@ -22,6 +22,23 @@ TEST_CASE("OsmDataFile setters and getters", "[OsmDataFile]")
     REQUIRE(file.localFile() == "abc");
 }
 
+TEST_CASE("DataSource basic properties", "[DataSource]")
+{
+    OsmDataFile file;
+    REQUIRE(DataSource::primarySourceName() == "Primary");
+
+    file.setUserName("u");
+    file.setDataName("d");
+    QDateTime t = QDateTime::currentDateTimeUtc();
+    file.setImportTime(t);
+    file.setImportDurationS(7);
+
+    REQUIRE(file.userName() == "u");
+    REQUIRE(file.dataName() == "d");
+    REQUIRE(file.importTime() == t);
+    REQUIRE(file.importDurationS() == 7);
+}
+
 TEST_CASE("OsmDataFile XML round trip", "[OsmDataFile]")
 {
     OsmDataFile file;

--- a/tests/stylelayer_test.cpp
+++ b/tests/stylelayer_test.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 #include "stylelayer.h"
 #include <QCoreApplication>
 #include <QEvent>
@@ -164,4 +165,65 @@ TEST_CASE("StyleLayer renderSQLSelect includes joins", "[StyleLayer]")
 
     app.processEvents();
     QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+}
+
+TEST_CASE("StyleLayer save and load point", "[StyleLayer]")
+{
+    int argc = 0;
+    QCoreApplication app(argc, nullptr);
+
+    StyleLayer layer("ds", "k", ST_POINT);
+    Point pt;
+    pt.name_ = "pt";
+    pt.minZoom_ = 2;
+    pt.color_ = QColor(Qt::green);
+    pt.opacity_ = 0.5;
+    pt.image_ = "img";
+    pt.width_ = 7;
+    layer.setSubLayerPoint(0, pt);
+
+    Label lb;
+    lb.visible_ = true;
+    lb.text_ = "[name]";
+    lb.color_ = QColor(Qt::yellow);
+    lb.height_ = 8;
+    layer.setLabel(0, lb);
+
+    QDomDocument doc;
+    QDomElement elem = doc.createElement("layer");
+    layer.saveXML(doc, elem);
+    doc.appendChild(elem);
+
+    StyleLayer loaded(elem);
+    REQUIRE(loaded.layerType() == ST_POINT);
+    Point loadedPt = loaded.subLayerPoint(0);
+    REQUIRE(loadedPt.name_ == "pt");
+    REQUIRE(loadedPt.minZoom_ == 2);
+    REQUIRE(loadedPt.color_ == QColor(Qt::green));
+    REQUIRE(loadedPt.opacity_ == Catch::Approx(0.5));
+    REQUIRE(loadedPt.image_ == "img");
+    REQUIRE(loadedPt.width_ == Catch::Approx(7.0));
+    Label loadedLb = loaded.label(0);
+    REQUIRE(loadedLb.visible_);
+    REQUIRE(loadedLb.text_ == "[name]");
+    REQUIRE(loadedLb.color_ == QColor(Qt::yellow));
+    REQUIRE(loadedLb.height_ == Catch::Approx(8.0));
+
+    app.processEvents();
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+}
+
+TEST_CASE("StyleLayer removeSubLayer for points", "[StyleLayer]")
+{
+    StyleLayer layer("ds", "k", ST_POINT);
+    Point p1;
+    p1.width_ = 1.0;
+    Point p2;
+    p2.width_ = 2.0;
+    layer.setSubLayerPoint(0, p1);
+    layer.setSubLayerPoint(1, p2);
+    REQUIRE(layer.subLayerCount() == 2);
+    layer.removeSubLayer(0);
+    REQUIRE(layer.subLayerCount() == 1);
+    REQUIRE(layer.subLayerPoint(0).width_ == Catch::Approx(2.0));
 }


### PR DESCRIPTION
## Summary
- extend stylelayer tests to cover point save/load and removal
- exercise DataSource getters and primarySourceName
- regenerate coverage report

## Testing
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `cmake --build bin/coverage -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_686730bb973483308963b7a6e2bd32a7