### PR TITLE
Update dependencies script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To see example output, visit [grotontrails.org](http://www.grotontrails.org) and
 
 The project relies on the following libraries:
 
-- Qt 5 (Widgets, Core, and Xml)
+- Qt 5 (Widgets, Core, Xml, and XmlPatterns)
 - BZip2
 - Zlib
 - Expat
@@ -20,6 +20,8 @@ The project relies on the following libraries:
 - GEOS
 - Libosmium
 - Catch2
+
+Development and testing also require `clang-format`, `lcov`, and `valgrind`.
 
 On Debian-based systems you can install them with `install_dependencies.sh`.
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -4,8 +4,11 @@ set -e
 sudo apt-get update
 sudo apt-get install -y build-essential cmake \
     qtbase5-dev qtbase5-dev-tools qttools5-dev-tools \
+    libqt5xmlpatterns5 libqt5xmlpatterns5-dev \
+    qt5-doc qt5-doc-html qtbase5-doc-html qtbase5-examples \
     libbz2-dev zlib1g-dev libexpat1-dev \
-    libproj-dev libsqlite3-dev libsqlitecpp-dev \
-    libgeos-dev libgeos++-dev libosmium2-dev \
-    catch2
+    libproj-dev clang-format lcov \
+    libsqlite3-dev sqlite3-doc libsqlitecpp-dev \
+    libgeos-dev libgeos++-dev libgeos-doc catch2 \
+    libosmium2-dev valgrind libosmium2-doc
 


### PR DESCRIPTION
## Summary
- install Qt5 xmlpatterns and dev packages
- add doc packages and dev tools like clang-format and valgrind
- document Qt5 xmlpatterns and developer tools in README

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug`
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/debug -j$(nproc)`
- `cmake --build bin/coverage -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`

------
https://chatgpt.com/codex/tasks/task_e_686736e708448330ac2c1e0d8cfff6eb