### PR TITLE
Fix vector not cleared in breakLines

### DIFF
--- a/mapmaker/linebreaking.cpp
+++ b/mapmaker/linebreaking.cpp
@@ -2,6 +2,7 @@
 
 void breakLines(std::vector<int>& words, int maxLineWidth, std::vector<size_t>* breaks)
 {
+    breaks->clear();
     if (words.size() > 0) {
         int lineLength = words[0];
         for (size_t i = 1; i < words.size(); ++i) {

--- a/tests/coverage_report.txt
+++ b/tests/coverage_report.txt
@@ -10,8 +10,8 @@ textfield.cpp                     | 4.5%     44| 0.0%     2|    -      0
 stylelayer.cpp                    | 8.7%    530| 0.0%    45|    -      0
 datasource.cpp                    |25.0%     60| 0.0%    14|    -      0
 osmdatafile.cpp                   |33.3%     24| 0.0%     8|    -      0
-linebreaking.cpp                  |11.1%      9| 0.0%     1|    -      0
+linebreaking.cpp                  |10.0%     10| 0.0%     1|    -      0
 osmdatadirectdownload.cpp         |50.0%     10| 0.0%     4|    -      0
 osmdataextractdownload.cpp        |50.0%     10| 0.0%     4|    -      0
                                   |Lines       |Functions  |Branches    
-                            Total:|13.2%   1156| 0.0%   142|    -      0
+                            Total:|13.2%   1157| 0.0%   142|    -      0


### PR DESCRIPTION
## Summary
- clear the breaks vector at the start of `breakLines`
- regenerate coverage report

## Testing
- `cmake --build bin/release -j$(nproc)`
- `ctest --output-on-failure --test-dir bin/release`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --output-on-failure --test-dir bin/valgrind`
- `cmake --build bin/coverage -j$(nproc)`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_686743d6c51c8330afd715c170805b41