### PR TITLE
Refactor SQL into RenderDatabase

### DIFF
--- a/mapmaker/renderdatabase.cpp
+++ b/mapmaker/renderdatabase.cpp
@@ -104,3 +104,36 @@ RenderDatabase::SchemaStatus RenderDatabase::schemaStatus()
     }
     return SchemaStatus::Upgradeable;
 }
+
+std::vector<QString> RenderDatabase::allKeysByFrequency()
+{
+    std::vector<QString> keys;
+    SQLite::Statement query(*this, "select key, count(key) as freq from entityKV group by key order by freq desc");
+    while (query.executeStep()) {
+        keys.push_back(query.getColumn(0).getText());
+    }
+    return keys;
+}
+
+std::vector<QString> RenderDatabase::keysByFrequency(const QString& dataSource)
+{
+    std::vector<QString> keys;
+    SQLite::Statement query(*this, "select key, count(key) as freq from entityKV, entity where entity.source = ? and entity.id = entityKV.id group by key order by freq desc");
+    query.bind(1, dataSource.toStdString());
+    while (query.executeStep()) {
+        keys.push_back(query.getColumn(0).getText());
+    }
+    return keys;
+}
+
+std::vector<QString> RenderDatabase::valuesByFrequency(const QString& dataSource, const QString& key)
+{
+    std::vector<QString> values;
+    SQLite::Statement query(*this, "select value, count(value) as freq from entityKV, entity where entity.source = ? and entity.id = entityKV.id and entityKV.key = ? group by value order by freq desc");
+    query.bind(1, dataSource.toStdString());
+    query.bind(2, key.toStdString());
+    while (query.executeStep()) {
+        values.push_back(query.getColumn(0).getText());
+    }
+    return values;
+}

--- a/mapmaker/renderdatabase.h
+++ b/mapmaker/renderdatabase.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QString>
+#include <vector>
 #include <string>
 #include <SQLiteCpp/SQLiteCpp.h>
 
@@ -24,4 +25,13 @@ public:
     int latestVersion();
     SchemaStatus schemaStatus();
     void upgrade();
+
+    /// Return all keys ordered by frequency of occurrence.
+    std::vector<QString> allKeysByFrequency();
+
+    /// Return keys for a specific data source ordered by frequency.
+    std::vector<QString> keysByFrequency(const QString& dataSource);
+
+    /// Return values for a given key/data source ordered by frequency.
+    std::vector<QString> valuesByFrequency(const QString& dataSource, const QString& key);
 };

--- a/osmmapmakerapp/newtoplevelstyle.cpp
+++ b/osmmapmakerapp/newtoplevelstyle.cpp
@@ -21,13 +21,8 @@ NewStopLeveStyle::NewStopLeveStyle(Project* project, QWidget* parent)
         ui->dataSource->addItem(name);
     }
 
-    SQLite::Statement query(*db, "select key, count(key) as freq from entityKV group by key order by freq desc");
-
-    while (query.executeStep()) {
-        const char* key = query.getColumn(0);
-        int count = query.getColumn(1);
-
-        keys_.push_back(QString(key));
+    for (const QString& key : db->allKeysByFrequency()) {
+        keys_.push_back(key);
         ui->keyList->addItem(key);
     }
 

--- a/osmmapmakerapp/selectvalueeditdialog.cpp
+++ b/osmmapmakerapp/selectvalueeditdialog.cpp
@@ -14,11 +14,7 @@ SelectValueEditDialog::SelectValueEditDialog(RenderDatabase* db, const QString& 
     dataSource_ = dataSource;
     surpressSelectChangeSignals_ = false;
 
-    SQLite::Statement query(*db_, "select key, count(key) as freq from entityKV, entity where entity.source = ? and entity.id = entityKV.id group by key order by freq desc");
-    query.bind(1, dataSource_.toStdString());
-
-    while (query.executeStep()) {
-        const char* key = query.getColumn(0);
+    for (const QString& key : db_->keysByFrequency(dataSource_)) {
         keys_.push_back(key);
     }
 
@@ -95,15 +91,10 @@ void SelectValueEditDialog::updateKeyLists()
 
 void SelectValueEditDialog::updateValueListFull()
 {
-    SQLite::Statement query(*db_, "select value, count(value) as freq from entityKV, entity where entity.source = ? and entity.id = entityKV.id and entityKV.key = ? group by value order by freq desc");
-    query.bind(1, dataSource_.toStdString());
-    query.bind(2, ui->key->text().toStdString());
-
     values_.clear();
     values_.push_back("*");
 
-    while (query.executeStep()) {
-        const char* value = query.getColumn(0);
+    for (const QString& value : db_->valuesByFrequency(dataSource_, ui->key->text())) {
         values_.push_back(value);
     }
 }

--- a/tests/coverage_report.txt
+++ b/tests/coverage_report.txt
@@ -4,18 +4,18 @@
 Filename                          |Rate     Num|Rate    Num|Rate     Num
 project.h                         |50.0%      6| 0.0%     3|    -      0
 output.cpp                        |27.6%     87| 0.0%    23|    -      0
-osmdata.cpp                       | 8.2%    182| 0.0%    14|    -      0
-project.cpp                       |14.0%    215| 0.0%    26|    -      0
+osmdata.cpp                       | 8.2%    183| 0.0%    14|    -      0
+project.cpp                       |15.3%    190| 0.0%    25|    -      0
 renderqt.cpp                      |    -      0|    -     0|    -      0
 textfield.cpp                     | 4.5%     44| 0.0%     2|    -      0
 stylelayer.cpp                    | 8.7%    530| 0.0%    45|    -      0
 datasource.cpp                    |25.0%     60| 0.0%    14|    -      0
 osmdatafile.cpp                   |33.3%     24| 0.0%     8|    -      0
 linebreaking.cpp                  |10.0%     10| 0.0%     1|    -      0
-renderdatabase.cpp                |17.1%     41| 0.0%     6|    -      0
+renderdatabase.cpp                |28.6%     49| 0.0%     8|    -      0
 batchtileoutput.cpp               | 9.5%     42| 0.0%     2|    -      0
 osmdataoverpass.cpp               |56.2%     16| 0.0%     5|    -      0
 osmdatadirectdownload.cpp         |50.0%     10| 0.0%     4|    -      0
 osmdataextractdownload.cpp        |50.0%     10| 0.0%     4|    -      0
                                   |Lines       |Functions  |Branches    
-                            Total:|14.3%   1277| 0.0%   157|    -      0
+                            Total:|15.0%   1261| 0.0%   158|    -      0

--- a/tests/osmdata_test.cpp
+++ b/tests/osmdata_test.cpp
@@ -171,13 +171,12 @@ TEST_CASE("Rendering sample OSM files import", "[OsmData]")
 
     for (const QString& fileName : files) {
         RenderDatabase rdb;
-        SQLite::Database& db = rdb.db();
 
         OsmDataFile data;
         data.SetLocalFile(dir.filePath(fileName));
-        data.importData(db);
+        data.importData(rdb);
 
-        SQLite::Statement countStmt(db, "SELECT COUNT(*) FROM entity");
+        SQLite::Statement countStmt(rdb, "SELECT COUNT(*) FROM entity");
         REQUIRE(countStmt.executeStep());
         REQUIRE(countStmt.getColumn(0).getInt() > 0);
     }


### PR DESCRIPTION
## Summary
- centralize key/value SQL queries in RenderDatabase
- use new helpers in NewStopLeveStyle and SelectValueEditDialog
- update tests for the new API
- regenerate coverage report

## Testing
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/coverage`
- `valgrind --tool=memcheck bin/valgrind/tests/hello_test`
- `valgrind --tool=helgrind bin/valgrind/tests/hello_test`


------
https://chatgpt.com/codex/tasks/task_e_6868562d0f248330818029a482acf7f9