### PR TITLE
Fix variable spelling

### DIFF
--- a/mapmaker/datasource.cpp
+++ b/mapmaker/datasource.cpp
@@ -101,7 +101,7 @@ void DataSource::cleanDataSource(RenderDatabase& db)
     removeDataStatement.bind(1, dataName().toStdString());
     removeDataStatement.exec();
 
-    // clean out the spatial index, can't setup a trigger for it because it is a virtual table.
-    SQLite::Statement removeSpatialIndextatement(db, "DELETE FROM entitySpatialIndex WHERE NOT EXISTS (SELECT * FROM entitySpatialIndex,entity WHERE entitySpatialIndex.pkid = entity.id)");
-    removeSpatialIndextatement.exec();
+    // clean out the spatial index, can't set up a trigger for it because it is a virtual table.
+    SQLite::Statement removeSpatialIndexStatement(db, "DELETE FROM entitySpatialIndex WHERE NOT EXISTS (SELECT * FROM entitySpatialIndex,entity WHERE entitySpatialIndex.pkid = entity.id)");
+    removeSpatialIndexStatement.exec();
 }

--- a/mapmaker/renderqt.cpp
+++ b/mapmaker/renderqt.cpp
@@ -17,19 +17,19 @@ RenderQT::RenderQT(Project* project, int dpiScale)
     scale_ = dpiScale;
 }
 
-void RenderQT::SetupZoomAtCenter(int imageWithPixels, int imageHeightPixels, double centerX, double centerY, double pixelResolution)
+void RenderQT::SetupZoomAtCenter(int imageWidthPixels, int imageHeightPixels, double centerX, double centerY, double pixelResolution)
 {
-    imageWithPixels_ = imageWithPixels;
+    imageWidthPixels_ = imageWidthPixels;
     imageHeightPixels_ = imageHeightPixels;
-    left_ = centerX - imageWithPixels / 2 * pixelResolution;
-    right_ = centerX + imageWithPixels / 2 * pixelResolution;
+    left_ = centerX - imageWidthPixels / 2 * pixelResolution;
+    right_ = centerX + imageWidthPixels / 2 * pixelResolution;
     bottom_ = centerY - imageHeightPixels / 2 * pixelResolution;
     top_ = centerY + imageHeightPixels / 2 * pixelResolution;
 }
 
-void RenderQT::SetupZoomBoundingBox(int imageWithPixels, int imageHeightPixels, double left, double right, double bottom, double top)
+void RenderQT::SetupZoomBoundingBox(int imageWidthPixels, int imageHeightPixels, double left, double right, double bottom, double top)
 {
-    imageWithPixels_ = imageWithPixels;
+    imageWidthPixels_ = imageWidthPixels;
     imageHeightPixels_ = imageHeightPixels;
     left_ = left;
     right_ = right;
@@ -39,13 +39,13 @@ void RenderQT::SetupZoomBoundingBox(int imageWithPixels, int imageHeightPixels, 
 
 QImage RenderQT::RenderImage()
 {
-    QImage img(imageWithPixels_, imageHeightPixels_, QImage::Format_ARGB32_Premultiplied);
+    QImage img(imageWidthPixels_, imageHeightPixels_, QImage::Format_ARGB32_Premultiplied);
 
     QPainter painter(&img);
     painter.setRenderHint(QPainter::Antialiasing, true);
 
     QColor backgroundColor = project_->backgroundColor();
-    painter.fillRect(0, 0, imageWithPixels_, imageHeightPixels_, backgroundColor);
+    painter.fillRect(0, 0, imageWidthPixels_, imageHeightPixels_, backgroundColor);
 
     auto zoomToScale = std::map<int, double>();
     zoomToScale[0] = 1000000000 / scale_;
@@ -88,9 +88,9 @@ void RenderQT::RenderGeom(QPainter& painter, std::map<int, double>& zoomToScale)
     transform1.translate(-left_, -top_);
 
     QTransform transform2;
-    transform2.scale(imageWithPixels_ / (right_ - left_), -imageHeightPixels_ / (top_ - bottom_));
+    transform2.scale(imageWidthPixels_ / (right_ - left_), -imageHeightPixels_ / (top_ - bottom_));
 
-    double penScaleMPerPixel = (right_ - left_) / imageWithPixels_;
+    double penScaleMPerPixel = (right_ - left_) / imageWidthPixels_;
 
     QTransform t = transform1 * transform2;
 
@@ -374,7 +374,7 @@ void RenderQT::RenderGeom(QPainter& painter, std::map<int, double>& zoomToScale)
 
 void RenderQT::RenderLabels(QPainter& painter, std::map<int, double>& zoomToScale)
 {
-    double penScaleMPerPixel = (right_ - left_) / imageWithPixels_;
+    double penScaleMPerPixel = (right_ - left_) / imageWidthPixels_;
 
     painter.resetTransform();
 
@@ -569,7 +569,7 @@ void RenderQT::RenderLabels(QPainter& painter, std::map<int, double>& zoomToScal
 
                         QFontMetricsF metrics(*font);
 
-                        double xScale = imageWithPixels_ / (right_ - left_);
+                        double xScale = imageWidthPixels_ / (right_ - left_);
                         double yScale = imageHeightPixels_ / (top_ - bottom_);
 
                         switch (projectLayer->layerType()) {

--- a/mapmaker/renderqt.h
+++ b/mapmaker/renderqt.h
@@ -10,14 +10,14 @@ public:
 
     QImage RenderImage();
 
-    void SetupZoomAtCenter(int imageWithPixels, int imageHeightPixels, double centerX, double centerY, double pixelResolution);
-    void SetupZoomBoundingBox(int imageWithPixels, int imageHeightPixels, double left, double right, double bottom, double top);
+    void SetupZoomAtCenter(int imageWidthPixels, int imageHeightPixels, double centerX, double centerY, double pixelResolution);
+    void SetupZoomBoundingBox(int imageWidthPixels, int imageHeightPixels, double left, double right, double bottom, double top);
 
 private:
     void RenderGeom(QPainter& painter, std::map<int, double>& zoomScale);
     void RenderLabels(QPainter& painter, std::map<int, double>& zoomScale);
 
-    int imageWithPixels_;
+    int imageWidthPixels_;
     int imageHeightPixels_;
     double left_;
     double right_;


### PR DESCRIPTION
## Summary
- fix misspelled variable names in data source cleanup
- rename imageWithPixels to imageWidthPixels

## Testing
- `cmake --build bin/release -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `valgrind --tool=memcheck --suppressions=valgrind.supp bin/valgrind/tests/hello_test`
- `valgrind --tool=helgrind --suppressions=valgrind.supp bin/valgrind/tests/hello_test`
- `cmake --build bin/coverage -j$(nproc)`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_68685c4775dc833090d20a84e74ccb35