### PR TITLE
Refactor cleanDataSource SQL

### DIFF
--- a/mapmaker/datasource.cpp
+++ b/mapmaker/datasource.cpp
@@ -96,12 +96,5 @@ void DataSource::setImportDurationS(int timeS)
 
 void DataSource::cleanDataSource(RenderDatabase& db)
 {
-    // clean out the entity, entityKV deleted with a trigger.
-    SQLite::Statement removeDataStatement(db, "DELETE FROM entity WHERE source = ?");
-    removeDataStatement.bind(1, dataName().toStdString());
-    removeDataStatement.exec();
-
-    // clean out the spatial index, can't set up a trigger for it because it is a virtual table.
-    SQLite::Statement removeSpatialIndexStatement(db, "DELETE FROM entitySpatialIndex WHERE NOT EXISTS (SELECT * FROM entitySpatialIndex,entity WHERE entitySpatialIndex.pkid = entity.id)");
-    removeSpatialIndexStatement.exec();
+    db.cleanDataSource(dataName());
 }

--- a/mapmaker/renderdatabase.cpp
+++ b/mapmaker/renderdatabase.cpp
@@ -137,3 +137,17 @@ std::vector<QString> RenderDatabase::valuesByFrequency(const QString& dataSource
     }
     return values;
 }
+
+void RenderDatabase::cleanDataSource(const QString& dataSource)
+{
+    // clean out the entity table, entityKV records are removed via trigger
+    SQLite::Statement removeData(*this, "DELETE FROM entity WHERE source = ?");
+    removeData.bind(1, dataSource.toStdString());
+    removeData.exec();
+
+    // clean out the spatial index - cannot use trigger on virtual table
+    SQLite::Statement removeIndex(
+        *this,
+        "DELETE FROM entitySpatialIndex WHERE NOT EXISTS (SELECT * FROM entitySpatialIndex,entity WHERE entitySpatialIndex.pkid = entity.id)");
+    removeIndex.exec();
+}

--- a/mapmaker/renderdatabase.h
+++ b/mapmaker/renderdatabase.h
@@ -34,4 +34,7 @@ public:
 
     /// Return values for a given key/data source ordered by frequency.
     std::vector<QString> valuesByFrequency(const QString& dataSource, const QString& key);
+
+    /// Remove all data belonging to a given source.
+    void cleanDataSource(const QString& dataSource);
 };

--- a/tests/coverage_report.txt
+++ b/tests/coverage_report.txt
@@ -9,13 +9,13 @@ project.cpp                       |15.3%    190| 0.0%    25|    -      0
 renderqt.cpp                      |    -      0|    -     0|    -      0
 textfield.cpp                     | 4.5%     44| 0.0%     2|    -      0
 stylelayer.cpp                    | 8.7%    530| 0.0%    45|    -      0
-datasource.cpp                    |25.0%     60| 0.0%    14|    -      0
+datasource.cpp                    |26.8%     56| 0.0%    14|    -      0
 osmdatafile.cpp                   |33.3%     24| 0.0%     8|    -      0
 linebreaking.cpp                  |10.0%     10| 0.0%     1|    -      0
-renderdatabase.cpp                |28.6%     49| 0.0%     8|    -      0
+renderdatabase.cpp                |26.8%     56| 0.0%     9|    -      0
 batchtileoutput.cpp               | 9.5%     42| 0.0%     2|    -      0
 osmdataoverpass.cpp               |56.2%     16| 0.0%     5|    -      0
 osmdatadirectdownload.cpp         |50.0%     10| 0.0%     4|    -      0
 osmdataextractdownload.cpp        |50.0%     10| 0.0%     4|    -      0
                                   |Lines       |Functions  |Branches    
-                            Total:|15.0%   1261| 0.0%   158|    -      0
+                            Total:|15.0%   1264| 0.0%   159|    -      0


### PR DESCRIPTION
## Summary
- move complex cleanDataSource SQL into RenderDatabase
- expose RenderDatabase::cleanDataSource helper
- update coverage report

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug`
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/debug -j$(nproc)`
- `cmake --build bin/coverage -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/coverage`
- `valgrind --tool=memcheck --quiet bin/valgrind/tests/hello_test` *(and other tests)*
- `valgrind --tool=helgrind --quiet bin/valgrind/tests/hello_test` *(and other tests)*
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_6868719dd2f48330b87dc0445ee2e357