### PR TITLE
Add metersPerPixel utility and enable test

### DIFF
--- a/mapmaker/CMakeLists.txt
+++ b/mapmaker/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SRC_FILES
     batchtileoutput.cpp
     renderqt.cpp
     linebreaking.cpp
+    maputils.cpp
 )
 add_library(mapmaker STATIC ${SRC_FILES} resources.qrc)
 

--- a/mapmaker/maputils.cpp
+++ b/mapmaker/maputils.cpp
@@ -1,0 +1,13 @@
+#include "maputils.h"
+
+namespace {
+constexpr double kEarthEquatorialRadiusMeters = 6378137.0;
+constexpr double kTileSize = 256.0;
+constexpr double kInitialMetersPerPixel = 2 * M_PI * kEarthEquatorialRadiusMeters / kTileSize;
+constexpr double kDegToRad = M_PI / 180.0;
+}
+
+double metersPerPixel(double latDeg, int zoom)
+{
+    return kInitialMetersPerPixel * std::cos(latDeg * kDegToRad) / std::pow(2.0, zoom);
+}

--- a/mapmaker/maputils.h
+++ b/mapmaker/maputils.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <cmath>
+
+/// Utility functions for geographic calculations.
+/// Returns the meters per pixel for a given latitude (degrees)
+/// and zoom level.
+double metersPerPixel(double latDeg, int zoom);

--- a/osmmapmakerapp/styleTab.cpp
+++ b/osmmapmakerapp/styleTab.cpp
@@ -7,6 +7,7 @@
 #include <QColorDialog>
 
 #include <renderqt.h>
+#include "maputils.h"
 
 #include "newtoplevelstyle.h"
 
@@ -94,7 +95,7 @@ void StyleTab::setProject(Project* project)
     project_->convertDataToMap(lon, latitude, &centerX_, &centerY_);
 
     ui->zoom->setValue(13);
-    updatePixelResultionFromZoom();
+    updatePixelResolutionFromZoom();
 
     delete render_;
     render_ = NULL;
@@ -381,7 +382,7 @@ void StyleTab::on_zoom_editingFinished()
     /*
     renderedImage_ = QImage();
 
-    updatePixelResultionFromZoom();
+    updatePixelResolutionFromZoom();
 
     render_->SetupZoomAtCenter(width() - renderImageLeft(), height(), centerX_, centerY_, pixelResolution_);
     renderedImage_ = render_->RenderImage();
@@ -396,7 +397,7 @@ void StyleTab::on_zoomIn_clicked()
 
     ui->zoom->setValue(ui->zoom->value() + 1);
 
-    updatePixelResultionFromZoom();
+    updatePixelResolutionFromZoom();
 
     render_->SetupZoomAtCenter(width() - renderImageLeft(), height(), centerX_, centerY_, pixelResolution_);
     renderedImage_ = render_->RenderImage();
@@ -410,7 +411,7 @@ void StyleTab::on_zoomOut_clicked()
 
     ui->zoom->setValue(ui->zoom->value() - 1);
 
-    updatePixelResultionFromZoom();
+    updatePixelResolutionFromZoom();
 
     render_->SetupZoomAtCenter(width() - renderImageLeft(), height(), centerX_, centerY_, pixelResolution_);
     renderedImage_ = render_->RenderImage();
@@ -418,12 +419,12 @@ void StyleTab::on_zoomOut_clicked()
     repaint();
 }
 
-void StyleTab::updatePixelResultionFromZoom()
+void StyleTab::updatePixelResolutionFromZoom()
 {
     double latitude, lon;
     project_->convertMapToData(centerX_, centerY_, &lon, &latitude);
 
-    pixelResolution_ = 156543.03 * cos(latitude * 0.01745329251994329576923690768489) / pow(2, ui->zoom->value());
+    pixelResolution_ = metersPerPixel(latitude, ui->zoom->value());
 }
 
 void StyleTab::mouseMoveEvent(QMouseEvent* mevent)

--- a/osmmapmakerapp/styleTab.h
+++ b/osmmapmakerapp/styleTab.h
@@ -97,7 +97,7 @@ private:
     void saveArea();
     void savePoint();
     void moveTreeItem(int direction);
-    void updatePixelResultionFromZoom();
+    void updatePixelResolutionFromZoom();
 
     SubLayerTextPage* lineLabelPage_;
     SubLayerTextPage* areaLabelPage_;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,11 @@ target_compile_features(hello_test PRIVATE cxx_std_17)
 
 add_test(NAME hello_test COMMAND hello_test)
 
+add_executable(maputils_test maputils_test.cpp)
+target_link_libraries(maputils_test PRIVATE Catch2::Catch2WithMain mapmaker)
+target_compile_features(maputils_test PRIVATE cxx_std_17)
+add_test(NAME maputils_test COMMAND maputils_test)
+
 add_executable(textfieldprocessor_test textfieldprocessor_test.cpp)
 target_link_libraries(textfieldprocessor_test PRIVATE Catch2::Catch2WithMain mapmaker)
 target_compile_features(textfieldprocessor_test PRIVATE cxx_std_17)

--- a/tests/coverage_report.txt
+++ b/tests/coverage_report.txt
@@ -7,6 +7,7 @@ output.cpp                        |27.6%     87| 0.0%    23|    -      0
 osmdata.cpp                       | 8.2%    183| 0.0%    14|    -      0
 project.cpp                       |15.3%    190| 0.0%    25|    -      0
 renderqt.cpp                      |    -      0|    -     0|    -      0
+maputils.cpp                      |50.0%      2| 0.0%     1|    -      0
 textfield.cpp                     | 4.5%     44| 0.0%     2|    -      0
 stylelayer.cpp                    | 8.7%    530| 0.0%    45|    -      0
 datasource.cpp                    |25.0%     60| 0.0%    14|    -      0
@@ -18,4 +19,4 @@ osmdataoverpass.cpp               |56.2%     16| 0.0%     5|    -      0
 osmdatadirectdownload.cpp         |50.0%     10| 0.0%     4|    -      0
 osmdataextractdownload.cpp        |50.0%     10| 0.0%     4|    -      0
                                   |Lines       |Functions  |Branches    
-                            Total:|15.0%   1261| 0.0%   158|    -      0
+                            Total:|15.0%   1263| 0.0%   159|    -      0

--- a/tests/maputils_test.cpp
+++ b/tests/maputils_test.cpp
@@ -1,0 +1,18 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+#include "maputils.h"
+using Catch::Approx;
+
+TEST_CASE("metersPerPixel at equator zoom0", "[maputils]")
+{
+    double mpp = metersPerPixel(0.0, 0);
+    REQUIRE(mpp == Approx(156543.03392).epsilon(0.00001));
+}
+
+TEST_CASE("metersPerPixel varies with latitude and zoom", "[maputils]")
+{
+    double lat = 45.0; // mid latitude
+    int zoom = 3;
+    double expected = 156543.03392 * std::cos(lat * M_PI / 180.0) / std::pow(2.0, zoom);
+    REQUIRE(metersPerPixel(lat, zoom) == Approx(expected).epsilon(0.00001));
+}


### PR DESCRIPTION
## Summary
- add `maputils.cpp` to mapmaker sources
- build and register `maputils_test`
- regenerate coverage report

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake --build bin/release -j$(nproc)`
- `ctest --test-dir bin/release`
- `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build bin/debug -j$(nproc)`
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake --build bin/coverage -j$(nproc)`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/valgrind`
- `valgrind --tool=memcheck --quiet --suppressions=valgrind.supp bin/valgrind/tests/area_test`
- `valgrind --tool=helgrind --quiet --suppressions=valgrind.supp bin/valgrind/tests/maputils_test`


------
https://chatgpt.com/codex/tasks/task_e_68685c15a9508330acb1867df26aa05b