### PR TITLE
Add project file option and remove default path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# osmmapmaker
+#osmmapmaker
 
 osmmapmaker is a desktop application for creating static maps directly from OpenStreetMap data. It aims to be simple enough that non-engineers can import OSM data, style their maps, and generate the tiles from within the application.
 
 The program includes its own stylesheet system, which is easier to use than Mapnik XML, CartoCSS, or Mapbox GL JS. Because the data is imported without filtering, any information available in OpenStreetMap can be used to build specialized maps.
 
 To see example output, visit [grotontrails.org](http://www.grotontrails.org) and choose the interactive maps.
+
+The application accepts a `--project` command line option to open a project file directly. If this option is omitted, a file picker will be shown on startup so you can choose the project to load.
 
 ## Dependencies
 
@@ -24,4 +26,3 @@ The project relies on the following libraries:
 Development and testing also require `clang-format`, `lcov`, and `valgrind`.
 
 On Debian-based systems you can install them with `install_dependencies.sh`.
-

--- a/osmmapmakerapp/main.cpp
+++ b/osmmapmakerapp/main.cpp
@@ -1,13 +1,25 @@
 #include "mainwindow.h"
 #include <QApplication>
 #include <QMessageBox>
+#include <QCommandLineParser>
+#include <filesystem>
 
 int main(int argc, char* argv[])
 {
     QApplication a(argc, argv);
 
+    QCommandLineParser parser;
+    parser.addHelpOption();
+    QCommandLineOption projectOption(QStringList() << "project", "Project file to open.", "file");
+    parser.addOption(projectOption);
+    parser.process(a);
+
+    std::filesystem::path projectPath;
+    if (parser.isSet(projectOption))
+        projectPath = parser.value(projectOption).toStdString();
+
     try {
-        MainWindow w;
+        MainWindow w(projectPath);
         w.showMaximized();
 
         return a.exec();

--- a/osmmapmakerapp/mainwindow.cpp
+++ b/osmmapmakerapp/mainwindow.cpp
@@ -12,7 +12,7 @@
 #include <QStandardPaths>
 #include <QApplication>
 
-MainWindow::MainWindow(QWidget* parent)
+MainWindow::MainWindow(path projectPath, QWidget* parent)
     : QMainWindow(parent)
     , ui(new Ui::MainWindow)
 {
@@ -23,9 +23,16 @@ MainWindow::MainWindow(QWidget* parent)
 
     project_ = NULL;
 
-    try {
-        openProject("C:\\Remillard\\Documents\\osmmapmaker\\projects\\groton-trail.osmmap.xml");
-    } catch (std::exception&) {
+    bool opened = false;
+    if (!projectPath.empty()) {
+        try {
+            openProject(projectPath);
+            opened = true;
+        } catch (std::exception&) {
+        }
+    }
+
+    if (!opened) {
         auto locs = QStandardPaths::standardLocations(QStandardPaths::HomeLocation);
         QString loc;
         if (locs.size() > 0)

--- a/osmmapmakerapp/mainwindow.h
+++ b/osmmapmakerapp/mainwindow.h
@@ -3,6 +3,8 @@
 #include <QMainWindow>
 
 #include "project.h"
+#include <filesystem>
+using std::filesystem::path;
 
 namespace Ui {
 class MainWindow;
@@ -12,7 +14,7 @@ class MainWindow : public QMainWindow {
     Q_OBJECT
 
 public:
-    explicit MainWindow(QWidget* parent = 0);
+    explicit MainWindow(path projectPath = path(), QWidget* parent = 0);
     ~MainWindow();
 
 private slots:

--- a/tests/coverage_report.txt
+++ b/tests/coverage_report.txt
@@ -1,22 +1,23 @@
-========================================================================
-========================================================================
-[/workspace/osmmapmaker/mapmaker/]
-Filename                          |Rate     Num|Rate    Num|Rate     Num
-project.h                         |50.0%      6| 0.0%     3|    -      0
-output.cpp                        |27.6%     87| 0.0%    23|    -      0
-osmdata.cpp                       | 8.2%    182| 0.0%    14|    -      0
-project.cpp                       |15.3%    190| 0.0%    25|    -      0
-renderqt.cpp                      |    -      0|    -     0|    -      0
-maputils.cpp                      |50.0%      2| 0.0%     1|    -      0
-textfield.cpp                     | 4.5%     44| 0.0%     2|    -      0
-stylelayer.cpp                    | 8.7%    530| 0.0%    45|    -      0
-datasource.cpp                    |26.8%     56| 0.0%    14|    -      0
-osmdatafile.cpp                   |33.3%     24| 0.0%     8|    -      0
-linebreaking.cpp                  |10.0%     10| 0.0%     1|    -      0
-renderdatabase.cpp                |26.8%     56| 0.0%     9|    -      0
-batchtileoutput.cpp               | 9.5%     42| 0.0%     2|    -      0
-osmdataoverpass.cpp               |56.2%     16| 0.0%     5|    -      0
-osmdatadirectdownload.cpp         |50.0%     10| 0.0%     4|    -      0
-osmdataextractdownload.cpp        |50.0%     10| 0.0%     4|    -      0
-                                  |Lines       |Functions  |Branches    
-                            Total:|15.1%   1265| 0.0%   160|    -      0
+================================================================================
+================================================================================
+[/workspace/osmmapmaker/]
+Filename                                       |Rate    Num|Rate  Num|Rate   Num
+mapmaker/project.h                             |50.0%     6| 0.0%   3|    -    0
+mapmaker/output.cpp                            |27.6%    87| 0.0%  23|    -    0
+mapmaker/osmdata.cpp                           | 8.2%   182| 0.0%  14|    -    0
+mapmaker/project.cpp                           |15.2%   191| 0.0%  25|    -    0
+mapmaker/renderqt.cpp                          |    -     0|    -   0|    -    0
+mapmaker/maputils.cpp                          |50.0%     2| 0.0%   1|    -    0
+mapmaker/textfield.cpp                         | 4.5%    44| 0.0%   2|    -    0
+mapmaker/stylelayer.cpp                        | 8.7%   530| 0.0%  45|    -    0
+mapmaker/datasource.cpp                        |26.8%    56| 0.0%  14|    -    0
+mapmaker/osmdatafile.cpp                       |33.3%    24| 0.0%   8|    -    0
+mapmaker/linebreaking.cpp                      |10.0%    10| 0.0%   1|    -    0
+mapmaker/renderdatabase.cpp                    |25.9%    58| 0.0%   9|    -    0
+mapmaker/batchtileoutput.cpp                   | 9.5%    42| 0.0%   2|    -    0
+mapmaker/osmdataoverpass.cpp                   |56.2%    16| 0.0%   5|    -    0
+mapmaker/osmdatadirectdownload.cpp             |50.0%    10| 0.0%   4|    -    0
+mapmaker/osmdataextractdownload.cpp            |50.0%    10| 0.0%   4|    -    0
+                                               |Lines      |Functions|Branches  
+bin/coverage/mapmaker/...mapmaker_resources.cpp|38.5%    13| 0.0%   5|    -    0
+                                         Total:|15.3%  1281| 0.0% 165|    -    0


### PR DESCRIPTION
## Summary
- remove hard coded project path
- add `--project` command line option
- show file picker if no project is provided
- document the option in the README
- update coverage report

## Testing
- `cmake --build bin/release -j$(nproc)`
- `ctest --output-on-failure --test-dir bin/release`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/valgrind`
- `cmake --build bin/coverage -j$(nproc)`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`

------
https://chatgpt.com/codex/tasks/task_e_686894b97e2c833094d98101596ec4bd