### PR TITLE
Implement Recent Projects MRU

### DIFF
--- a/mapmaker/CMakeLists.txt
+++ b/mapmaker/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SRC_FILES
     renderqt.cpp
     linebreaking.cpp
     maputils.cpp
+    applicationpreferences.cpp
 )
 add_library(mapmaker STATIC ${SRC_FILES} mapmaker_resources.qrc)
 

--- a/mapmaker/applicationpreferences.cpp
+++ b/mapmaker/applicationpreferences.cpp
@@ -1,0 +1,78 @@
+#include "applicationpreferences.h"
+#include <QStandardPaths>
+#include <QDir>
+#include <QFile>
+
+QString ApplicationPreferences::appDataDir()
+{
+    QString env = qEnvironmentVariable("OSMMAPMAKER_APPDATA");
+    if (!env.isEmpty()) {
+        QDir d(env);
+        d.mkpath(".");
+        return d.absolutePath();
+    }
+    QString loc = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    // QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) returns
+    // a per-user directory suitable for storing persistent application data.
+    // The path is never empty unless the location cannot be determined.
+    // Typical results:
+    //   - Linux:   ~/.local/share/<APPNAME>
+    //   - macOS:   ~/Library/Application Support/<APPNAME>
+    //   - Windows: C:/Users/<user>/AppData/Roaming/<APPNAME>
+    // Set QCoreApplication::setOrganizationName and setApplicationName so
+    // <APPNAME> expands correctly.
+    QDir d(loc);
+    d.mkpath(".");
+    return d.absolutePath();
+}
+
+std::filesystem::path ApplicationPreferences::mruFilePath()
+{
+    QString f = appDataDir() + "/recent_projects.txt";
+    return std::filesystem::path(f.toStdString());
+}
+
+QStringList ApplicationPreferences::readMRU()
+{
+    QStringList list;
+    QFile f(appDataDir() + "/recent_projects.txt");
+    if (f.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        while (!f.atEnd()) {
+            QString line = QString::fromUtf8(f.readLine()).trimmed();
+            if (!line.isEmpty())
+                list.append(line);
+        }
+    }
+    return list;
+}
+
+void ApplicationPreferences::saveMRU(const QStringList& paths)
+{
+    QFile f(appDataDir() + "/recent_projects.txt");
+    if (f.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+        for (const QString& p : paths) {
+            f.write(p.toUtf8());
+            f.write("\n");
+        }
+    }
+}
+
+void ApplicationPreferences::addProjectToMRU(const QString& projectPath)
+{
+    QStringList list = readMRU();
+    list.removeAll(projectPath);
+    list.prepend(projectPath);
+    while (list.size() > ApplicationPreferences::MAX_ENTRIES_MRU)
+        list.removeLast();
+    saveMRU(list);
+}
+
+QString ApplicationPreferences::mostRecentExistingMRU()
+{
+    QStringList list = readMRU();
+    for (const QString& p : list) {
+        if (QFile::exists(p))
+            return p;
+    }
+    return QString();
+}

--- a/mapmaker/applicationpreferences.h
+++ b/mapmaker/applicationpreferences.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <QStringList>
+#include <filesystem>
+
+/// Application-wide preferences stored under the user's application data
+/// directory. Currently manages the list of recently opened projects but is
+/// intended to centralize other persisted settings in the future.
+class ApplicationPreferences {
+public:
+    /// Directory where the MRU file resides. Respects the optional
+    /// OSMMAPMAKER_APPDATA environment override.
+    static QString appDataDir();
+
+    /// Location of the MRU file on disk.
+    static std::filesystem::path mruFilePath();
+
+    /// Read the MRU list from disk. Missing files return an empty list.
+    static QStringList readMRU();
+
+    /// Save the provided project paths to disk.
+    static void saveMRU(const QStringList& paths);
+
+    /// Add a path to the MRU list, keeping only the newest MAX_ENTRIES_MRU items.
+    static void addProjectToMRU(const QString& projectPath);
+
+    /// Return the first project in the MRU list that still exists on disk.
+    static QString mostRecentExistingMRU();
+
+    static constexpr int MAX_ENTRIES_MRU = 15; ///< Maximum number of paths stored
+};

--- a/osmmapmakerapp/mainwindow.cpp
+++ b/osmmapmakerapp/mainwindow.cpp
@@ -6,11 +6,13 @@
 #include "outputTab.h"
 
 #include "project.h"
+#include "applicationpreferences.h"
 
 #include <QMessageBox>
 #include <QFileDialog>
 #include <QStandardPaths>
 #include <QApplication>
+#include <QFile>
 
 MainWindow::MainWindow(path projectPath, QWidget* parent)
     : QMainWindow(parent)
@@ -20,6 +22,8 @@ MainWindow::MainWindow(path projectPath, QWidget* parent)
     ui->tabWidget->addTab(new DataTab(this), tr("Data"));
     ui->tabWidget->addTab(new StyleTab(this), tr("Style"));
     ui->tabWidget->addTab(new OutputTab(this), tr("Output"));
+    recentMenu_ = ui->menuRecentProjects;
+    updateRecentMenu();
 
     project_ = NULL;
 
@@ -29,6 +33,17 @@ MainWindow::MainWindow(path projectPath, QWidget* parent)
             openProject(projectPath);
             opened = true;
         } catch (std::exception&) {
+        }
+    }
+
+    if (!opened) {
+        QString recent = ApplicationPreferences::mostRecentExistingMRU();
+        if (!recent.isEmpty()) {
+            try {
+                openProject(recent.toStdString());
+                opened = true;
+            } catch (std::exception&) {
+            }
         }
     }
 
@@ -72,6 +87,9 @@ void MainWindow::openProject(path projectPath)
     } else {
         ui->tabWidget->setCurrentIndex(1);
     }
+
+    ApplicationPreferences::addProjectToMRU(QString::fromStdWString(projectPath.wstring()));
+    updateRecentMenu();
 }
 
 MainWindow::~MainWindow()
@@ -97,10 +115,7 @@ void MainWindow::on_action_Project_Open_triggered()
     QString file = QFileDialog::getOpenFileName(this, tr("Open Project"), loc, tr("Map Project Files (*.xml)"));
 
     if (file.isEmpty() == false) {
-        QMessageBox msgBox(this);
-
-        msgBox.setText(QString("Open %1").arg(file));
-        msgBox.exec();
+        openProject(file.toStdString());
     }
 }
 
@@ -133,4 +148,31 @@ void MainWindow::on_action_Project_Save_triggered()
 void MainWindow::on_actionExit_triggered()
 {
     this->close();
+}
+
+void MainWindow::openRecentProject()
+{
+    QAction* a = qobject_cast<QAction*>(sender());
+    if (!a)
+        return;
+    QString path = a->data().toString();
+    if (!path.isEmpty())
+        openProject(path.toStdString());
+}
+
+void MainWindow::updateRecentMenu()
+{
+    recentMenu_->clear();
+    QStringList list = ApplicationPreferences::readMRU();
+    int added = 0;
+    for (const QString& p : list) {
+        if (!QFile::exists(p))
+            continue;
+        QAction* act = recentMenu_->addAction(p);
+        act->setData(p);
+        connect(act, &QAction::triggered, this, &MainWindow::openRecentProject);
+        if (++added >= MAX_MENU_RECENT)
+            break;
+    }
+    recentMenu_->setEnabled(added > 0);
 }

--- a/osmmapmakerapp/mainwindow.h
+++ b/osmmapmakerapp/mainwindow.h
@@ -3,6 +3,7 @@
 #include <QMainWindow>
 
 #include "project.h"
+#include "applicationpreferences.h"
 #include <filesystem>
 using std::filesystem::path;
 
@@ -24,9 +25,15 @@ private slots:
     void on_action_Project_Copy_triggered();
     void on_action_Project_Save_triggered();
 
+    void openRecentProject();
+
     void openProject(path projectPath);
+    void updateRecentMenu();
 
 private:
     Ui::MainWindow* ui;
     Project* project_ = NULL;
+    QMenu* recentMenu_ = nullptr;
+
+    static constexpr int MAX_MENU_RECENT = 5;
 };

--- a/osmmapmakerapp/mainwindow.ui
+++ b/osmmapmakerapp/mainwindow.ui
@@ -47,6 +47,12 @@
     <addaction name="action_Project_Open"/>
     <addaction name="action_Project_Save"/>
     <addaction name="action_Project_Copy"/>
+    <widget class="QMenu" name="menuRecentProjects">
+     <property name="title">
+      <string>Recent Projects</string>
+     </property>
+    </widget>
+    <addaction name="menuRecentProjects"/>
     <addaction name="actionExit"/>
    </widget>
    <addaction name="menuProject"/>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -148,3 +148,8 @@ target_link_libraries(overpass_test PRIVATE
 target_compile_features(overpass_test PRIVATE cxx_std_17)
 target_compile_definitions(overpass_test PRIVATE SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 add_test(NAME overpass_test COMMAND overpass_test)
+
+add_executable(applicationpreferences_test applicationpreferences_test.cpp)
+target_link_libraries(applicationpreferences_test PRIVATE Catch2::Catch2WithMain mapmaker)
+target_compile_features(applicationpreferences_test PRIVATE cxx_std_17)
+add_test(NAME applicationpreferences_test COMMAND applicationpreferences_test)

--- a/tests/applicationpreferences_test.cpp
+++ b/tests/applicationpreferences_test.cpp
@@ -1,0 +1,67 @@
+#include <catch2/catch_test_macros.hpp>
+#include <QCoreApplication>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QTemporaryFile>
+#include "applicationpreferences.h"
+
+TEST_CASE("Recent project list persists", "[ApplicationPreferences]")
+{
+    int argc = 0;
+    QCoreApplication app(argc, nullptr);
+
+    QTemporaryDir dir;
+    qputenv("OSMMAPMAKER_APPDATA", dir.path().toUtf8());
+
+    ApplicationPreferences::addProjectToMRU("/tmp/proj1.osmmap.xml");
+    ApplicationPreferences::addProjectToMRU("/tmp/proj2.osmmap.xml");
+    ApplicationPreferences::addProjectToMRU("/tmp/proj3.osmmap.xml");
+
+    QStringList list = ApplicationPreferences::readMRU();
+    REQUIRE(list.size() == 3);
+    REQUIRE(list.first() == "/tmp/proj3.osmmap.xml");
+
+    // Simulate new session
+    QStringList list2 = ApplicationPreferences::readMRU();
+    REQUIRE(list2 == list);
+}
+
+TEST_CASE("Most recent existing project selected", "[ApplicationPreferences]")
+{
+    int argc = 0;
+    QCoreApplication app(argc, nullptr);
+
+    QTemporaryDir dir;
+    qputenv("OSMMAPMAKER_APPDATA", dir.path().toUtf8());
+
+    QTemporaryFile f(dir.path() + "/proj.osmmap.xml");
+    REQUIRE(f.open());
+    QString p = f.fileName();
+
+    ApplicationPreferences::addProjectToMRU("/does/not/exist.osmmap.xml");
+    ApplicationPreferences::addProjectToMRU(p);
+
+    QString recent = ApplicationPreferences::mostRecentExistingMRU();
+    REQUIRE(recent == p);
+}
+
+TEST_CASE("Utility functions return expected paths", "[ApplicationPreferences]")
+{
+    int argc = 0;
+    QCoreApplication app(argc, nullptr);
+
+    QTemporaryDir dir;
+    qputenv("OSMMAPMAKER_APPDATA", dir.path().toUtf8());
+
+    QString ad = ApplicationPreferences::appDataDir();
+    REQUIRE(ad == dir.path());
+
+    auto mru = ApplicationPreferences::mruFilePath();
+    REQUIRE(QString::fromStdString(mru.parent_path().string()) == dir.path());
+
+    QStringList paths;
+    paths << "/tmp/proj1.xml";
+    ApplicationPreferences::saveMRU(paths);
+    QStringList loaded = ApplicationPreferences::readMRU();
+    REQUIRE(loaded == paths);
+}

--- a/tests/coverage_report.txt
+++ b/tests/coverage_report.txt
@@ -17,7 +17,8 @@ mapmaker/renderdatabase.cpp                    |25.9%    58| 0.0%   9|    -    0
 mapmaker/batchtileoutput.cpp                   | 9.5%    42| 0.0%   2|    -    0
 mapmaker/osmdataoverpass.cpp                   |56.2%    16| 0.0%   5|    -    0
 mapmaker/osmdatadirectdownload.cpp             |50.0%    10| 0.0%   4|    -    0
+mapmaker/applicationpreferences.cpp            |14.0%    43| 0.0%   6|    -    0
 mapmaker/osmdataextractdownload.cpp            |50.0%    10| 0.0%   4|    -    0
                                                |Lines      |Functions|Branches  
 bin/coverage/mapmaker/...mapmaker_resources.cpp|38.5%    13| 0.0%   5|    -    0
-                                         Total:|15.4%  1275| 0.0% 165|    -    0
+                                         Total:|15.3%  1318| 0.0% 171|    -    0


### PR DESCRIPTION
## Summary
- add an application-wide preferences helper
- document how QStandardPaths selects the app data directory
- store the recent projects MRU via ApplicationPreferences
- rename unit test accordingly and update CMake
- regenerate coverage report
- rename constant for max entries in MRU

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug`
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/debug -j$(nproc)`
- `cmake --build bin/coverage -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/valgrind`
- `valgrind --tool=memcheck --quiet --suppressions=valgrind.supp bin/valgrind/tests/hello_test` (sample)
- `valgrind --tool=helgrind --quiet --suppressions=valgrind.supp bin/valgrind/tests/project_schema_test` (sample)
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_6868a2742de08330b6da6f81306e6c79