### PR TITLE
Add daily logging task

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ The project relies on the following libraries:
 
 Development and testing also require `clang-format`, `lcov`, and `valgrind`.
 
-On Debian-based systems you can install them with `install_dependencies.sh`.
+On Debian-based systems you can install them with `install_dependencies_apt.sh`.

--- a/TODO.md
+++ b/TODO.md
@@ -248,3 +248,18 @@ Duplicate an existing project to a different location for experimentation.
 
 ### Automated Testing
 - Verify the copied project opens correctly and produces the same output as the original.
+
+## Daily Logging to File
+### Goal
+Capture trace output in a rotating log so issues can be diagnosed easily.
+
+### Specification
+1. Use the header-only [spdlog](https://github.com/gabime/spdlog) library for cross‑platform logging.
+2. Create a daily logger that writes to `Preferences::logDirectory()/osmmapmaker.log` so the location can be customized by the user.
+3. Rotate (delete) the previous log at startup so each run begins fresh.
+4. Provide a small wrapper that initializes the logger and exposes simple `log::info` style functions.
+5. Allow logging to be disabled in release builds via a compile flag.
+
+### Automated Testing
+- Launch the application twice and verify the log file from the first run is removed before the second begins.
+- Run the unit test suite and confirm no log file is created.

--- a/install_dependencies_apt.sh
+++ b/install_dependencies_apt.sh
@@ -10,5 +10,6 @@ sudo apt-get install -y build-essential cmake \
     libproj-dev clang-format lcov \
     libsqlite3-dev sqlite3-doc libsqlitecpp-dev \
     libgeos-dev libgeos++-dev libgeos-doc catch2 \
-    libosmium2-dev valgrind libosmium2-doc
+    libosmium2-dev valgrind libosmium2-doc \
+    libspdlog-dev
 


### PR DESCRIPTION
## Summary
- document a new logging task
- add libspdlog-dev to dependencies and rename script

## Testing
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/debug -j$(nproc)`
- `cmake --build bin/coverage -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/valgrind`
- `valgrind --tool=memcheck --suppressions=valgrind.supp <test>` and `valgrind --tool=helgrind --suppressions=valgrind.supp <test>` for each test binary
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_6868ad08aa6c8330ae5e10c602db3336