### PR TITLE
Implement improved project template handling

### DIFF
--- a/mapmaker/CMakeLists.txt
+++ b/mapmaker/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SRC_FILES
     renderqt.cpp
     linebreaking.cpp
     maputils.cpp
+    projecttemplate.cpp
 )
 add_library(mapmaker STATIC ${SRC_FILES} mapmaker_resources.qrc)
 

--- a/mapmaker/mapmaker_resources.qrc
+++ b/mapmaker/mapmaker_resources.qrc
@@ -5,5 +5,9 @@
         <file>resources/render-1.sql</file>
         <file>resources/areaKeys.json</file>
         <file>resources/discarded.txt</file>
+        <file>resources/templates/template_empty.osmmap.xml</file>
+        <file>resources/templates/template_point.osmmap.xml</file>
+        <file>resources/templates/template_line.osmmap.xml</file>
+        <file>resources/templates/template_area.osmmap.xml</file>
     </qresource>
 </RCC>

--- a/mapmaker/project.h
+++ b/mapmaker/project.h
@@ -19,6 +19,11 @@ public:
     Project(path filename);
     ~Project();
 
+    /// Create a new project from a template. Throws std::runtime_error on failure.
+    static void createNew(const QString& projectName,
+        const std::filesystem::path& directory,
+        const QByteArray& templateData);
+
     void save();
     void save(path filename);
 

--- a/mapmaker/projecttemplate.cpp
+++ b/mapmaker/projecttemplate.cpp
@@ -1,0 +1,39 @@
+#include "projecttemplate.h"
+#include <QFile>
+#include <stdexcept>
+
+namespace {
+
+static const std::vector<ProjectTemplate::Info> kTemplates = {
+    { "Empty", "Empty project with no layers." },
+    { "Point", "Single point layer example." },
+    { "Line", "Single line layer example." },
+    { "Area", "Single area layer example." },
+};
+
+static QString templateResource(const QString& id)
+{
+    QString lower = id.toLower();
+    if (lower == "point")
+        return ":/resources/templates/template_point.osmmap.xml";
+    if (lower == "line")
+        return ":/resources/templates/template_line.osmmap.xml";
+    if (lower == "area")
+        return ":/resources/templates/template_area.osmmap.xml";
+    return ":/resources/templates/template_empty.osmmap.xml";
+}
+
+} // namespace
+
+const std::vector<ProjectTemplate::Info>& ProjectTemplate::templates()
+{
+    return kTemplates;
+}
+
+QByteArray ProjectTemplate::projectTemplateContents(const QString& id)
+{
+    QFile in(templateResource(id));
+    if (!in.open(QIODevice::ReadOnly))
+        throw std::invalid_argument("Unknown template id: " + id.toStdString());
+    return in.readAll();
+}

--- a/mapmaker/projecttemplate.h
+++ b/mapmaker/projecttemplate.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <QString>
+#include <QByteArray>
+#include <filesystem>
+#include <vector>
+
+/// Provides access to built-in project templates embedded as Qt resources.
+class ProjectTemplate {
+public:
+    struct Info {
+        QString id;
+        QString description;
+    };
+
+    static const std::vector<Info>& templates();
+    static QByteArray projectTemplateContents(const QString& id);
+};

--- a/mapmaker/resources/templates/template_area.osmmap.xml
+++ b/mapmaker/resources/templates/template_area.osmmap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmmapmakerproject>
+ <openStreetMapDirectDownload name="remote">
+  <dataSource>Primary</dataSource>
+ </openStreetMapDirectDownload>
+ <openStreetMapExtractDownload name="remote2">
+  <dataSource>Secondary</dataSource>
+ </openStreetMapExtractDownload>
+ <map backgroundColor="#00ff00" backgroundOpacity="0.5">
+  <layer dataSource="Primary" k="landuse" type="area">
+   <subLayer name="forest" visible="true" minZoom="13">
+    <selector>
+     <condition key="landuse">
+      <value>forest</value>
+     </condition>
+    </selector>
+    <area>
+     <color>#00ff00</color>
+     <opacity>1</opacity>
+     <casingWidth>0</casingWidth>
+     <casingColor>#000000</casingColor>
+     <fillImage></fillImage>
+     <fillImageOpacity>1</fillImageOpacity>
+    </area>
+   </subLayer>
+  </layer>
+ </map>
+</osmmapmakerproject>

--- a/mapmaker/resources/templates/template_empty.osmmap.xml
+++ b/mapmaker/resources/templates/template_empty.osmmap.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmmapmakerproject>
+ <map/>
+</osmmapmakerproject>

--- a/mapmaker/resources/templates/template_line.osmmap.xml
+++ b/mapmaker/resources/templates/template_line.osmmap.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmmapmakerproject>
+ <tileOutput name="lineTiles">
+  <maxZoom>12</maxZoom>
+  <minZoom>10</minZoom>
+  <tileSize>256</tileSize>
+  <resolution1x>true</resolution1x>
+  <resolution2x>true</resolution2x>
+  <directory></directory>
+ </tileOutput>
+ <map backgroundColor="#ffffff" backgroundOpacity="1">
+  <layer dataSource="Primary" k="highway" type="line">
+   <subLayer name="roads" visible="true" minZoom="10">
+    <selector>
+     <condition key="highway">
+      <value>residential</value>
+     </condition>
+    </selector>
+    <line>
+     <color>#000000</color>
+     <casingColor>#ffffff</casingColor>
+     <width>1</width>
+     <casingWidth>1</casingWidth>
+     <opacity>1</opacity>
+     <smooth>0</smooth>
+     <dashArray></dashArray>
+    </line>
+    <label minZoom="12">
+     <text>[name]</text>
+     <height>12</height>
+     <weight>700</weight>
+     <color>#000000</color>
+     <haloSize>1</haloSize>
+     <haloColor>#ffffff</haloColor>
+     <maxWrapWidth>100</maxWrapWidth>
+     <offsetY>0</offsetY>
+     <priority>1</priority>
+    </label>
+   </subLayer>
+  </layer>
+ </map>
+</osmmapmakerproject>

--- a/mapmaker/resources/templates/template_point.osmmap.xml
+++ b/mapmaker/resources/templates/template_point.osmmap.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmmapmakerproject>
+ <openStreetMapFileSource name="local">
+  <dataSource>Primary</dataSource>
+  <fileName>data.osm</fileName>
+ </openStreetMapFileSource>
+ <tileOutput name="pointTiles">
+  <maxZoom>18</maxZoom>
+  <minZoom>15</minZoom>
+  <tileSize>256</tileSize>
+  <resolution1x>true</resolution1x>
+  <resolution2x>false</resolution2x>
+  <directory></directory>
+ </tileOutput>
+ <map>
+  <layer dataSource="Primary" k="amenity" type="point">
+   <subLayer name="poi" visible="true" minZoom="15">
+    <selector>
+     <condition key="amenity">
+      <value>restaurant</value>
+     </condition>
+    </selector>
+    <point>
+     <image>poi.png</image>
+     <opacity>1</opacity>
+     <color>#ff0000</color>
+     <width>1</width>
+    </point>
+   </subLayer>
+  </layer>
+ </map>
+</osmmapmakerproject>

--- a/osmmapmakerapp/CMakeLists.txt
+++ b/osmmapmakerapp/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SRC_FILES
     outputTab.cpp
     styleTab.cpp
     newtoplevelstyle.cpp
+    newprojectdialog.cpp
     subLayerTextPage.cpp
     sublayerselectpage.cpp
     selectvalueeditdialog.cpp)
@@ -22,6 +23,7 @@ set(UI_FILES
     outputTab.ui
     styleTab.ui
     newtoplevelstyle.ui
+    newprojectdialog.ui
     subLayerTextPage.ui
     sublayerselectpage.ui
     selectvalueeditdialog.ui)

--- a/osmmapmakerapp/mainwindow.cpp
+++ b/osmmapmakerapp/mainwindow.cpp
@@ -6,6 +6,8 @@
 #include "outputTab.h"
 
 #include "project.h"
+#include "newprojectdialog.h"
+#include "projecttemplate.h"
 
 #include <QMessageBox>
 #include <QFileDialog>
@@ -82,9 +84,30 @@ MainWindow::~MainWindow()
 
 void MainWindow::on_action_Project_New_triggered()
 {
-    QMessageBox msgBox(this);
-    msgBox.setText(QString("New"));
-    msgBox.exec();
+    NewProjectDialog dlg(this);
+    if (dlg.exec() == QDialog::Accepted) {
+        QString path = dlg.projectPath();
+        if (path.isEmpty())
+            return;
+
+        std::filesystem::path p = path.toStdString();
+        QString name = QString::fromStdString(p.stem().string());
+        std::filesystem::path dir = p.parent_path();
+
+        try {
+            QByteArray bytes = ProjectTemplate::projectTemplateContents(dlg.templateName());
+            Project::createNew(name, dir, bytes);
+        } catch (const std::exception& e) {
+            QMessageBox::warning(this, tr("New Project"), e.what());
+            return;
+        }
+
+        try {
+            openProject(path.toStdString());
+        } catch (std::exception& e) {
+            QMessageBox::warning(this, tr("New Project"), e.what());
+        }
+    }
 }
 
 void MainWindow::on_action_Project_Open_triggered()

--- a/osmmapmakerapp/newprojectdialog.cpp
+++ b/osmmapmakerapp/newprojectdialog.cpp
@@ -1,0 +1,37 @@
+#include "newprojectdialog.h"
+#include "ui_newprojectdialog.h"
+#include <QFileDialog>
+#include "projecttemplate.h"
+
+NewProjectDialog::NewProjectDialog(QWidget* parent)
+    : QDialog(parent)
+    , ui(new Ui::NewProjectDialog)
+{
+    ui->setupUi(this);
+
+    for (const auto& info : ProjectTemplate::templates()) {
+        ui->templateBox->addItem(info.description, info.id);
+    }
+}
+
+NewProjectDialog::~NewProjectDialog()
+{
+    delete ui;
+}
+
+QString NewProjectDialog::projectPath() const
+{
+    return ui->projectPath->text();
+}
+
+QString NewProjectDialog::templateName() const
+{
+    return ui->templateBox->currentData().toString();
+}
+
+void NewProjectDialog::on_browse_clicked()
+{
+    QString file = QFileDialog::getSaveFileName(this, tr("New Project"), QString(), tr("Map Project Files (*.osmmap.xml)"));
+    if (!file.isEmpty())
+        ui->projectPath->setText(file);
+}

--- a/osmmapmakerapp/newprojectdialog.h
+++ b/osmmapmakerapp/newprojectdialog.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <QDialog>
+
+namespace Ui {
+class NewProjectDialog;
+}
+
+class NewProjectDialog : public QDialog {
+    Q_OBJECT
+public:
+    explicit NewProjectDialog(QWidget* parent = nullptr);
+    ~NewProjectDialog();
+
+    QString projectPath() const;
+    QString templateName() const;
+
+private slots:
+    void on_browse_clicked();
+
+private:
+    Ui::NewProjectDialog* ui;
+};

--- a/osmmapmakerapp/newprojectdialog.ui
+++ b/osmmapmakerapp/newprojectdialog.ui
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>NewProjectDialog</class>
+ <widget class="QDialog" name="NewProjectDialog">
+  <property name="windowTitle">
+   <string>New Project</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="labelPath">
+     <property name="text">
+      <string>Project File</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="projectPath"/>
+   </item>
+   <item row="0" column="2">
+    <widget class="QPushButton" name="browse">
+     <property name="text">
+      <string>Browse...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="labelTemplate">
+     <property name="text">
+      <string>Template</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" colspan="2">
+    <widget class="QComboBox" name="templateBox"/>
+   </item>
+   <item row="2" column="0" colspan="3">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>NewProjectDialog</receiver>
+   <slot>accept()</slot>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>NewProjectDialog</receiver>
+   <slot>reject()</slot>
+  </connection>
+ </connections>
+</ui>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -127,6 +127,50 @@ target_compile_features(project_load_save_test PRIVATE cxx_std_17)
 target_compile_definitions(project_load_save_test PRIVATE SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 add_test(NAME project_load_save_test COMMAND project_load_save_test)
 
+add_executable(new_project_test
+    new_project_test.cpp
+    ../osmmapmakerapp/resources.qrc
+)
+set_target_properties(new_project_test PROPERTIES AUTORCC ON)
+target_link_libraries(new_project_test PRIVATE
+    Catch2::Catch2WithMain
+    mapmaker
+    Qt5::XmlPatterns
+    BZip2::BZip2
+    ZLIB::ZLIB
+    EXPAT::EXPAT
+    PROJ::proj
+    SQLiteCpp
+    SQLite::SQLite3
+    GEOS::geos
+    GEOS::geos_c
+)
+target_compile_features(new_project_test PRIVATE cxx_std_17)
+target_compile_definitions(new_project_test PRIVATE SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+add_test(NAME new_project_test COMMAND new_project_test)
+
+add_executable(projecttemplate_test
+    projecttemplate_test.cpp
+    ../osmmapmakerapp/resources.qrc
+)
+set_target_properties(projecttemplate_test PROPERTIES AUTORCC ON)
+target_link_libraries(projecttemplate_test PRIVATE
+    Catch2::Catch2WithMain
+    mapmaker
+    Qt5::XmlPatterns
+    BZip2::BZip2
+    ZLIB::ZLIB
+    EXPAT::EXPAT
+    PROJ::proj
+    SQLiteCpp
+    SQLite::SQLite3
+    GEOS::geos
+    GEOS::geos_c
+)
+target_compile_features(projecttemplate_test PRIVATE cxx_std_17)
+target_compile_definitions(projecttemplate_test PRIVATE SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+add_test(NAME projecttemplate_test COMMAND projecttemplate_test)
+
 add_executable(overpass_test
     overpass_test.cpp
     ../osmmapmakerapp/resources.qrc

--- a/tests/coverage_report.txt
+++ b/tests/coverage_report.txt
@@ -5,7 +5,7 @@ Filename                                       |Rate    Num|Rate  Num|Rate   Num
 mapmaker/project.h                             |50.0%     6| 0.0%   3|    -    0
 mapmaker/output.cpp                            |27.6%    87| 0.0%  23|    -    0
 mapmaker/osmdata.cpp                           | 8.5%   176| 0.0%  14|    -    0
-mapmaker/project.cpp                           |15.2%   191| 0.0%  25|    -    0
+mapmaker/project.cpp                           |14.6%   206| 0.0%  26|    -    0
 mapmaker/renderqt.cpp                          |    -     0|    -   0|    -    0
 mapmaker/maputils.cpp                          |50.0%     2| 0.0%   1|    -    0
 mapmaker/textfield.cpp                         | 4.5%    44| 0.0%   2|    -    0
@@ -15,9 +15,10 @@ mapmaker/osmdatafile.cpp                       |33.3%    24| 0.0%   8|    -    0
 mapmaker/linebreaking.cpp                      |10.0%    10| 0.0%   1|    -    0
 mapmaker/renderdatabase.cpp                    |25.9%    58| 0.0%   9|    -    0
 mapmaker/batchtileoutput.cpp                   | 9.5%    42| 0.0%   2|    -    0
+mapmaker/projecttemplate.cpp                   |17.6%    17| 0.0%   3|    -    0
 mapmaker/osmdataoverpass.cpp                   |56.2%    16| 0.0%   5|    -    0
 mapmaker/osmdatadirectdownload.cpp             |50.0%    10| 0.0%   4|    -    0
 mapmaker/osmdataextractdownload.cpp            |50.0%    10| 0.0%   4|    -    0
                                                |Lines      |Functions|Branches  
 bin/coverage/mapmaker/...mapmaker_resources.cpp|38.5%    13| 0.0%   5|    -    0
-                                         Total:|15.4%  1275| 0.0% 165|    -    0
+                                         Total:|15.3%  1307| 0.0% 169|    -    0

--- a/tests/new_project_test.cpp
+++ b/tests/new_project_test.cpp
@@ -1,0 +1,44 @@
+#include <catch2/catch_test_macros.hpp>
+#include <QCoreApplication>
+#include <QXmlSchema>
+#include <QXmlSchemaValidator>
+#include <QFile>
+#include "project.h"
+#include "projecttemplate.h"
+
+TEST_CASE("Project templates create valid files", "[Project]")
+{
+    int argc = 0;
+    qputenv("QT_PLUGIN_PATH", "");
+    qputenv("QT_BEARER_POLL_TIMEOUT", "-1");
+    QCoreApplication app(argc, nullptr);
+    QCoreApplication::setLibraryPaths(QStringList());
+
+    QStringList templates = { "Empty", "Point", "Line", "Area" };
+
+    QXmlSchema schema;
+    QFile xsdFile(":/resources/project.xsd");
+    REQUIRE(xsdFile.open(QIODevice::ReadOnly));
+    schema.load(&xsdFile);
+    REQUIRE(schema.isValid());
+
+    for (const QString& t : templates) {
+        std::filesystem::path dir = std::filesystem::temp_directory_path() / ("tmp_" + t.toStdString());
+        std::filesystem::create_directories(dir);
+        QByteArray bytes = ProjectTemplate::projectTemplateContents(t);
+        REQUIRE_NOTHROW(Project::createNew("test", dir, bytes));
+        std::filesystem::path tmp = dir / "test.osmmap.xml";
+        QFile f(QString::fromStdString(tmp.string()));
+        REQUIRE(f.open(QIODevice::ReadOnly));
+        QXmlSchemaValidator validator(schema);
+        REQUIRE(validator.validate(&f));
+        f.close();
+        Project proj(tmp);
+        (void)proj; // ensure it loads
+        std::filesystem::remove_all(dir);
+    }
+
+    schema = QXmlSchema();
+    app.processEvents();
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+}

--- a/tests/osmdata_test.cpp
+++ b/tests/osmdata_test.cpp
@@ -6,7 +6,6 @@
 #include <QXmlSchema>
 #include <QXmlSchemaValidator>
 #include <QDir>
-#include <QNetworkAccessManager>
 #include <SQLiteCpp/SQLiteCpp.h>
 #include "renderdatabase.h"
 
@@ -182,10 +181,9 @@ TEST_CASE("Rendering sample OSM schema validation", "[OsmSchema]")
 {
     int argc = 0;
     qputenv("QT_PLUGIN_PATH", "");
+    qputenv("QT_BEARER_POLL_TIMEOUT", "-1");
     QCoreApplication app(argc, nullptr);
     QCoreApplication::setLibraryPaths(QStringList());
-    QNetworkAccessManager nam;
-    nam.setNetworkAccessible(QNetworkAccessManager::NotAccessible);
 
     QXmlSchema schema;
     QFile xsdFile(QStringLiteral(SOURCE_DIR "/tests/osm/osm_test.xsd"));

--- a/tests/overpass_test.cpp
+++ b/tests/overpass_test.cpp
@@ -1,5 +1,4 @@
 #include <catch2/catch_test_macros.hpp>
-#include <QNetworkAccessManager>
 #include <QtXml>
 #include <SQLiteCpp/SQLiteCpp.h>
 #include "osmdataoverpass.h"
@@ -7,16 +6,14 @@
 
 TEST_CASE("Overpass import uses cache", "[Overpass]")
 {
+    qputenv("QT_BEARER_POLL_TIMEOUT", "-1");
     RenderDatabase db;
-
-    QNetworkAccessManager nam;
-    nam.setNetworkAccessible(QNetworkAccessManager::NotAccessible);
 
     QString query = "node(0,0,1,1);out;";
     QByteArray osm = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><osm version=\"0.6\"><node id=\"1\" lat=\"0\" lon=\"0\"><tag k=\"name\" v=\"n1\"/></node></osm>";
     OsmDataOverpass::cache_.insert(query, osm);
 
-    OsmDataOverpass over(&nam);
+    OsmDataOverpass over(nullptr);
     over.setQuery(query);
     over.importData(db);
 
@@ -27,9 +24,8 @@ TEST_CASE("Overpass import uses cache", "[Overpass]")
 
 TEST_CASE("Overpass network failure throws", "[Overpass]")
 {
-    QNetworkAccessManager nam;
-    nam.setNetworkAccessible(QNetworkAccessManager::NotAccessible);
-    OsmDataOverpass over(&nam);
+    qputenv("QT_BEARER_POLL_TIMEOUT", "-1");
+    OsmDataOverpass over(nullptr);
     over.setQuery("foo");
 
     RenderDatabase db;

--- a/tests/project_load_save_test.cpp
+++ b/tests/project_load_save_test.cpp
@@ -5,7 +5,6 @@
 #include <QXmlSchema>
 #include <QXmlSchemaValidator>
 #include <QFile>
-#include <QNetworkAccessManager>
 #include <QEvent>
 #include <QStringList>
 #include "project.h"
@@ -18,10 +17,9 @@ TEST_CASE("Valid project files load and save", "[Project]")
 {
     int argc = 0;
     qputenv("QT_PLUGIN_PATH", "");
+    qputenv("QT_BEARER_POLL_TIMEOUT", "-1");
     QCoreApplication app(argc, nullptr);
     QCoreApplication::setLibraryPaths(QStringList());
-    QNetworkAccessManager nam;
-    nam.setNetworkAccessible(QNetworkAccessManager::NotAccessible);
 
     QXmlSchema schema;
     QFile xsdFile(":/resources/project.xsd");
@@ -72,8 +70,6 @@ TEST_CASE("Invalid project files fail validation", "[Project]")
     qputenv("QT_PLUGIN_PATH", "");
     QCoreApplication app(argc, nullptr);
     QCoreApplication::setLibraryPaths(QStringList());
-    QNetworkAccessManager nam;
-    nam.setNetworkAccessible(QNetworkAccessManager::NotAccessible);
 
     QXmlSchema schema;
     QFile xsdFile(":/resources/project.xsd");
@@ -108,8 +104,6 @@ TEST_CASE("Invalid project files throw on load", "[Project]")
     qputenv("QT_PLUGIN_PATH", "");
     QCoreApplication app(argc, nullptr);
     QCoreApplication::setLibraryPaths(QStringList());
-    QNetworkAccessManager nam;
-    nam.setNetworkAccessible(QNetworkAccessManager::NotAccessible);
 
     QStringList files = {
         QStringLiteral(SOURCE_DIR "/tests/project_xml_samples/invalid/invalid_no_map.osmmap.xml"),
@@ -144,8 +138,6 @@ TEST_CASE("Malformed project file reports parse location", "[Project]")
     qputenv("QT_PLUGIN_PATH", "");
     QCoreApplication app(argc, nullptr);
     QCoreApplication::setLibraryPaths(QStringList());
-    QNetworkAccessManager nam;
-    nam.setNetworkAccessible(QNetworkAccessManager::NotAccessible);
 
     QString fileName = QStringLiteral(SOURCE_DIR "/tests/project_xml_samples/malformed/malformed_missing_lt.osmmap.xml");
     std::filesystem::path p = fileName.toStdString();
@@ -169,8 +161,6 @@ TEST_CASE("Project coordinate conversions", "[Project]")
     qputenv("QT_PLUGIN_PATH", "");
     QCoreApplication app(argc, nullptr);
     QCoreApplication::setLibraryPaths(QStringList());
-    QNetworkAccessManager nam;
-    nam.setNetworkAccessible(QNetworkAccessManager::NotAccessible);
 
     QString fileName = QStringLiteral(SOURCE_DIR "/tests/project_xml_samples/valid/valid_point.osmmap.xml");
     std::filesystem::path p = fileName.toStdString();
@@ -207,8 +197,6 @@ TEST_CASE("Project add and remove components", "[Project]")
     qputenv("QT_PLUGIN_PATH", "");
     QCoreApplication app(argc, nullptr);
     QCoreApplication::setLibraryPaths(QStringList());
-    QNetworkAccessManager nam;
-    nam.setNetworkAccessible(QNetworkAccessManager::NotAccessible);
 
     QString fileName = QStringLiteral(SOURCE_DIR "/tests/project_xml_samples/valid/valid_point.osmmap.xml");
     std::filesystem::path p = fileName.toStdString();

--- a/tests/project_schema_test.cpp
+++ b/tests/project_schema_test.cpp
@@ -5,18 +5,16 @@
 #include <QUrl>
 #include <QCoreApplication>
 #include <QStringList>
-#include <QNetworkAccessManager>
 #include <QEvent>
 
 TEST_CASE("Project files validate against schema", "[ProjectSchema]")
 {
     int argc = 0;
     qputenv("QT_PLUGIN_PATH", "");
+    qputenv("QT_BEARER_POLL_TIMEOUT", "-1");
     QCoreApplication app(argc, nullptr);
     QCoreApplication::setLibraryPaths(QStringList());
     Q_INIT_RESOURCE(mapmaker_resources);
-    QNetworkAccessManager nam;
-    nam.setNetworkAccessible(QNetworkAccessManager::NotAccessible);
     QXmlSchema schema;
     QFile xsdFile(":/resources/project.xsd");
     REQUIRE(xsdFile.open(QIODevice::ReadOnly));

--- a/tests/projecttemplate_test.cpp
+++ b/tests/projecttemplate_test.cpp
@@ -1,0 +1,45 @@
+#include <catch2/catch_test_macros.hpp>
+#include <QCoreApplication>
+#include <QXmlSchema>
+#include <QXmlSchemaValidator>
+#include <QFile>
+#include "projecttemplate.h"
+#include "project.h"
+
+TEST_CASE("ProjectTemplate templates are valid", "[ProjectTemplate]")
+{
+    int argc = 0;
+    qputenv("QT_PLUGIN_PATH", "");
+    qputenv("QT_BEARER_POLL_TIMEOUT", "-1");
+    QCoreApplication app(argc, nullptr);
+    QCoreApplication::setLibraryPaths(QStringList());
+
+    const auto& infos = ProjectTemplate::templates();
+    REQUIRE(!infos.empty());
+
+    QXmlSchema schema;
+    QFile xsdFile(":/resources/project.xsd");
+    REQUIRE(xsdFile.open(QIODevice::ReadOnly));
+    schema.load(&xsdFile);
+    REQUIRE(schema.isValid());
+    QXmlSchemaValidator validator(schema);
+
+    for (const auto& info : infos) {
+        std::filesystem::path dir = std::filesystem::temp_directory_path() / ("tmpl_" + info.id.toStdString());
+        std::filesystem::create_directories(dir);
+        QByteArray bytes = ProjectTemplate::projectTemplateContents(info.id);
+        REQUIRE_NOTHROW(Project::createNew("test", dir, bytes));
+        std::filesystem::path filePath = dir / "test.osmmap.xml";
+        QFile file(QString::fromStdString(filePath.string()));
+        REQUIRE(file.open(QIODevice::ReadOnly));
+        REQUIRE(validator.validate(&file));
+        file.close();
+        Project p(filePath);
+        (void)p;
+        std::filesystem::remove_all(dir);
+    }
+
+    schema = QXmlSchema();
+    app.processEvents();
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+}


### PR DESCRIPTION
## Summary
- make `ProjectTemplate` provide template byte access
- replace `create()` function with `Project::createNew` writing bytes and throwing on failure
- adjust project creation dialog and tests to use new API
- regenerate coverage report

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake --build bin/release -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/release`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/valgrind`
- `valgrind -q --tool=memcheck --suppressions=valgrind.supp bin/valgrind/tests/area_test` *(and other test binaries)*
- `valgrind -q --tool=helgrind --suppressions=valgrind.supp bin/valgrind/tests/area_test` *(and other test binaries)*
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake --build bin/coverage -j$(nproc)`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_6868a23820c48330b514b437b6d41741