### PR TITLE
Add output CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ To see example output, visit [grotontrails.org](http://www.grotontrails.org) and
 
 The application accepts a `--project` command line option to open a project file directly. If this option is omitted, a file picker will be shown on startup so you can choose the project to load.
 
+An optional `--output` argument can be used to generate map outputs without launching the UI. When invoked as `--output` all configured outputs are written. When invoked as `--output <name>` only the specified output is generated.
+
 ## Dependencies
 
 The project relies on the following libraries:

--- a/osmmapmakerapp/main.cpp
+++ b/osmmapmakerapp/main.cpp
@@ -3,22 +3,82 @@
 #include <QMessageBox>
 #include <QCommandLineParser>
 #include <filesystem>
+#include "project.h"
+#include "batchtileoutput.h"
+
+struct OutputOption {
+    bool requested = false;
+    QString name;
+};
+
+static OutputOption parseOutputOption(QStringList& args)
+{
+    OutputOption opt;
+    for (int i = 1; i < args.size(); ++i) {
+        QString arg = args.at(i);
+        if (arg == "--output") {
+            opt.requested = true;
+            args.removeAt(i);
+            if (i < args.size() && !args.at(i).startsWith('-')) {
+                opt.name = args.at(i);
+                args.removeAt(i);
+            }
+            break;
+        } else if (arg.startsWith("--output=")) {
+            opt.requested = true;
+            opt.name = arg.mid(QString("--output=").size());
+            args.removeAt(i);
+            break;
+        }
+    }
+    return opt;
+}
 
 int main(int argc, char* argv[])
 {
     QApplication a(argc, argv);
 
+    QStringList args = a.arguments();
+    OutputOption outputOpt = parseOutputOption(args);
+
     QCommandLineParser parser;
     parser.addHelpOption();
     QCommandLineOption projectOption(QStringList() << "project", "Project file to open.", "file");
     parser.addOption(projectOption);
-    parser.process(a);
+    parser.process(args);
 
     std::filesystem::path projectPath;
     if (parser.isSet(projectOption))
         projectPath = parser.value(projectOption).toStdString();
 
     try {
+        if (outputOpt.requested) {
+            if (projectPath.empty())
+                throw std::runtime_error("--output requires --project <file>");
+
+            Project project(projectPath);
+
+            if (outputOpt.name.isEmpty()) {
+                for (Output* out : project.outputs()) {
+                    if (auto* t = dynamic_cast<TileOutput*>(out))
+                        BatchTileOutput::generateTiles(&project, *t);
+                }
+            } else {
+                bool found = false;
+                for (Output* out : project.outputs()) {
+                    if (out->name() == outputOpt.name) {
+                        if (auto* t = dynamic_cast<TileOutput*>(out)) {
+                            BatchTileOutput::generateTiles(&project, *t);
+                            found = true;
+                        }
+                    }
+                }
+                if (!found)
+                    throw std::runtime_error("No output named " + outputOpt.name.toStdString());
+            }
+            return EXIT_SUCCESS;
+        }
+
         MainWindow w(projectPath);
         w.showMaximized();
 


### PR DESCRIPTION
## Summary
- add `--output` command line option to run outputs from the CLI
- document the new option in README

## Testing
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`

------
https://chatgpt.com/codex/tasks/task_e_6868a4ac4e088330b2455b09c6b0c648