### PR TITLE
Fix progress dialog updates

### DIFF
--- a/osmmapmakerapp/outputTab.cpp
+++ b/osmmapmakerapp/outputTab.cpp
@@ -3,6 +3,7 @@
 
 #include "batchtileoutput.h"
 #include <QProgressDialog>
+#include <QApplication>
 
 OutputTab::OutputTab(QWidget* parent)
     : QWidget(parent)
@@ -226,6 +227,7 @@ void OutputTab::on_generate_clicked()
             [&dlg](int done, int total) {
                 dlg.setMaximum(total);
                 dlg.setValue(done);
+                QApplication::processEvents();
                 return !dlg.wasCanceled();
             });
 

--- a/tests/coverage_report.txt
+++ b/tests/coverage_report.txt
@@ -21,4 +21,4 @@ mapmaker/applicationpreferences.cpp            |14.0%    43| 0.0%   6|    -    0
 mapmaker/osmdataextractdownload.cpp            |50.0%    10| 0.0%   4|    -    0
                                                |Lines      |Functions|Branches  
 bin/coverage/mapmaker/...mapmaker_resources.cpp|38.5%    13| 0.0%   5|    -    0
-                                         Total:|15.5%  1275| 0.0% 165|    -    0
+                                         Total:|15.3%  1349| 0.0% 173|    -    0


### PR DESCRIPTION
## Summary
- include `QApplication` for progress dialog updates
- process UI events when updating tile generation progress
- update coverage report

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake --build bin/release -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `valgrind --tool=memcheck --suppressions=valgrind.supp bin/valgrind/tests/hello_test`
- `valgrind --tool=helgrind --suppressions=valgrind.supp bin/valgrind/tests/hello_test`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_686984d884108330994d726671c87389