### PR TITLE
Fix QNetworkAccessManager include

### DIFF
--- a/tests/coverage_report.txt
+++ b/tests/coverage_report.txt
@@ -6,7 +6,7 @@ mapmaker/project.h                             |50.0%     6| 0.0%   3|    -    0
 mapmaker/output.cpp                            |27.6%    87| 0.0%  23|    -    0
 mapmaker/demdata.cpp                           | 7.7%   155| 0.0%   7|    -    0
 mapmaker/osmdata.cpp                           | 8.5%   176| 0.0%  14|    -    0
-mapmaker/project.cpp                           |14.6%   206| 0.0%  26|    -    0
+mapmaker/project.cpp                           |13.9%   238| 0.0%  28|    -    0
 mapmaker/renderqt.cpp                          |    -     0|    -   0|    -    0
 mapmaker/maputils.cpp                          |50.0%     2| 0.0%   1|    -    0
 mapmaker/textfield.cpp                         | 4.5%    44| 0.0%   2|    -    0
@@ -15,13 +15,12 @@ mapmaker/datasource.cpp                        |26.8%    56| 0.0%  14|    -    0
 mapmaker/osmdatafile.cpp                       |33.3%    24| 0.0%   8|    -    0
 mapmaker/linebreaking.cpp                      |10.0%    10| 0.0%   1|    -    0
 mapmaker/renderdatabase.cpp                    |25.9%    58| 0.0%   9|    -    0
-mapmaker/batchtileoutput.cpp                   | 9.5%    42| 0.0%   2|    -    0
-mapmaker/projecttemplate.cpp                   |17.6%    17| 0.0%   3|    -    0
 mapmaker/batchtileoutput.cpp                   |14.3%    42| 0.0%   2|    -    0
+mapmaker/projecttemplate.cpp                   |17.6%    17| 0.0%   3|    -    0
 mapmaker/osmdataoverpass.cpp                   |56.2%    16| 0.0%   5|    -    0
 mapmaker/osmdatadirectdownload.cpp             |50.0%    10| 0.0%   4|    -    0
 mapmaker/applicationpreferences.cpp            |14.0%    43| 0.0%   6|    -    0
 mapmaker/osmdataextractdownload.cpp            |50.0%    10| 0.0%   4|    -    0
                                                |Lines      |Functions|Branches  
 bin/coverage/mapmaker/...mapmaker_resources.cpp|38.5%    13| 0.0%   5|    -    0
-                                         Total:|15.3%  1349| 0.0% 173|    -    0
+                                         Total:|14.5%  1537| 0.0% 184|    -    0

--- a/tests/project_load_save_test.cpp
+++ b/tests/project_load_save_test.cpp
@@ -7,6 +7,7 @@
 #include <QFile>
 #include <QEvent>
 #include <QStringList>
+#include <QNetworkAccessManager>
 #include "project.h"
 #include "osmdatafile.h"
 #include "stylelayer.h"


### PR DESCRIPTION
## Summary
- add missing `<QNetworkAccessManager>` include to `project_load_save_test.cpp`
- regenerate coverage report

## Testing
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/debug -j$(nproc)`
- `cmake --build bin/coverage -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/coverage`
- `valgrind --tool=memcheck --suppressions=valgrind.supp bin/valgrind/tests/applicationpreferences_test`
- `valgrind --tool=memcheck --suppressions=valgrind.supp bin/valgrind/tests/tileoutput_test`
- `valgrind --tool=helgrind --suppressions=valgrind.supp bin/valgrind/tests/applicationpreferences_test`
- `valgrind --tool=helgrind --suppressions=valgrind.supp bin/valgrind/tests/tileoutput_test`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_6869b0f575b48330ae7ec389bd466367