### PR TITLE
Fix minor issues in utilities

### DIFF
--- a/mapmaker/output.cpp
+++ b/mapmaker/output.cpp
@@ -6,9 +6,9 @@ Output::Output(QString nameIn)
 {
 }
 
-Output::Output(QDomElement ouputNode)
+Output::Output(QDomElement outputNode)
 {
-    name_ = ouputNode.attributes().namedItem("name").nodeValue();
+    name_ = outputNode.attributes().namedItem("name").nodeValue();
 }
 
 Output::~Output()
@@ -25,9 +25,9 @@ void Output::setName(QString name)
     name_ = name;
 }
 
-void Output::saveXML(QDomDocument& doc, QDomElement& ouputNode)
+void Output::saveXML(QDomDocument& doc, QDomElement& outputNode)
 {
-    ouputNode.setAttribute("name", name_);
+    outputNode.setAttribute("name", name_);
 }
 
 TileOutput::TileOutput(QString name)

--- a/mapmaker/output.h
+++ b/mapmaker/output.h
@@ -14,7 +14,7 @@ struct BoundingBox {
 class Output {
 public:
     Output(QString name);
-    Output(QDomElement ouputNode);
+    Output(QDomElement outputNode);
 
     virtual ~Output();
 
@@ -31,7 +31,7 @@ protected:
 class TileOutput : public Output {
 public:
     TileOutput(QString name);
-    TileOutput(QDomElement ouputNode);
+    TileOutput(QDomElement outputNode);
     ~TileOutput();
 
     int maxZoom() const;


### PR DESCRIPTION
## Summary
- fix typo in Output constructors and saveXML
- revert unintended changes in utility files
- regenerate coverage report

## Testing
- `cmake --build bin/release -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `cmake --build bin/coverage -j$(nproc)`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_6868abeed8d08330845a81968511410f