### PR TITLE
Add custom project color picker

### DIFF
--- a/osmmapmakerapp/CMakeLists.txt
+++ b/osmmapmakerapp/CMakeLists.txt
@@ -15,7 +15,8 @@ set(SRC_FILES
     newtoplevelstyle.cpp
     subLayerTextPage.cpp
     sublayerselectpage.cpp
-    selectvalueeditdialog.cpp)
+    selectvalueeditdialog.cpp
+    colorpickerdialog.cpp)
 set(UI_FILES
     mainwindow.ui
     dataTab.ui
@@ -24,7 +25,8 @@ set(UI_FILES
     newtoplevelstyle.ui
     subLayerTextPage.ui
     sublayerselectpage.ui
-    selectvalueeditdialog.ui)
+    selectvalueeditdialog.ui
+    colorpickerdialog.ui)
 
 add_executable(osmmapmakerapp ${APP_TYPE} ${SRC_FILES} ${UI_FILES} resources.qrc)
 

--- a/osmmapmakerapp/colorpickerdialog.cpp
+++ b/osmmapmakerapp/colorpickerdialog.cpp
@@ -1,0 +1,151 @@
+#include "colorpickerdialog.h"
+#include "ui_colorpickerdialog.h"
+
+#include <project.h>
+#include <stylelayer.h>
+#include <QListWidgetItem>
+#include <QPixmap>
+#include <algorithm>
+
+namespace {
+struct ColorInfo {
+    QColor color;
+    QStringList features;
+};
+}
+
+ColorPickerDialog::ColorPickerDialog(Project* project, QWidget* parent)
+    : QDialog(parent)
+    , ui(new Ui::ColorPickerDialog)
+{
+    ui->setupUi(this);
+    project_ = project;
+
+    populateColors();
+    updatePatch(QColor());
+}
+
+ColorPickerDialog::~ColorPickerDialog() { }
+
+QColor ColorPickerDialog::selectedColor() const { return color_; }
+
+void ColorPickerDialog::setCurrentColor(const QColor& color)
+{
+    color_ = color;
+    ui->colorWidget->setCurrentColor(color);
+    updatePatch(color);
+}
+
+QColor ColorPickerDialog::getColor(Project* project, const QColor& initial, QWidget* parent)
+{
+    ColorPickerDialog dlg(project, parent);
+    dlg.setCurrentColor(initial);
+    if (dlg.exec() == QDialog::Accepted)
+        return dlg.selectedColor();
+    return QColor();
+}
+
+void ColorPickerDialog::populateColors()
+{
+    if (!project_)
+        return;
+
+    // map color hex -> info
+    QMap<QString, ColorInfo> colorMap;
+
+    auto addColor = [&colorMap](const QColor& c, const QString& feature) {
+        QString key = c.name();
+        auto it = colorMap.find(key);
+        if (it == colorMap.end()) {
+            ColorInfo info;
+            info.color = c;
+            info.features << feature;
+            colorMap.insert(key, info);
+        } else {
+            if (!it->features.contains(feature))
+                it->features << feature;
+        }
+    };
+
+    addColor(project_->backgroundColor(), tr("Background"));
+
+    for (StyleLayer* layer : project_->styleLayers()) {
+        QString layerKey = layer->key();
+        std::vector<QString> names = layer->subLayerNames();
+        for (size_t i = 0; i < layer->subLayerCount(); ++i) {
+            QString prefix = QString("%1/%2").arg(layerKey, names[i]);
+            switch (layer->layerType()) {
+            case ST_POINT: {
+                Point p = layer->subLayerPoint(i);
+                addColor(p.color_, prefix + tr(" point"));
+                break;
+            }
+            case ST_LINE: {
+                Line l = layer->subLayerLine(i);
+                addColor(l.color_, prefix + tr(" line"));
+                addColor(l.casingColor_, prefix + tr(" line casing"));
+                break;
+            }
+            case ST_AREA: {
+                Area a = layer->subLayerArea(i);
+                addColor(a.color_, prefix + tr(" area"));
+                addColor(a.casingColor_, prefix + tr(" area border"));
+                break;
+            }
+            }
+            Label lb = layer->label(i);
+            addColor(lb.color_, prefix + tr(" label"));
+            addColor(lb.haloColor_, prefix + tr(" halo"));
+        }
+    }
+
+    std::vector<ColorInfo> colors;
+    for (auto it = colorMap.begin(); it != colorMap.end(); ++it)
+        colors.push_back(*it);
+    std::sort(colors.begin(), colors.end(), [](const ColorInfo& a, const ColorInfo& b) {
+        int ha = a.color.hslHue();
+        int hb = b.color.hslHue();
+        if (ha < 0)
+            ha = 361;
+        if (hb < 0)
+            hb = 361;
+        return ha < hb;
+    });
+
+    for (const ColorInfo& info : colors) {
+        QString label = info.features.join(", ");
+        QListWidgetItem* item = new QListWidgetItem(label);
+        QPixmap pm(20, 20);
+        pm.fill(info.color);
+        item->setIcon(QIcon(pm));
+        item->setData(Qt::UserRole, info.color);
+        item->setToolTip(label);
+        ui->usedColors->addItem(item);
+    }
+}
+
+void ColorPickerDialog::on_usedColors_itemClicked(QListWidgetItem* item)
+{
+    QColor c = item->data(Qt::UserRole).value<QColor>();
+    setCurrentColor(c);
+}
+
+void ColorPickerDialog::on_usedColors_itemDoubleClicked(QListWidgetItem* item)
+{
+    on_usedColors_itemClicked(item);
+    accept();
+}
+
+void ColorPickerDialog::on_colorWidget_currentColorChanged(const QColor& color)
+{
+    color_ = color;
+    updatePatch(color);
+}
+
+void ColorPickerDialog::updatePatch(const QColor& color)
+{
+    QPixmap pm(60, 60);
+    pm.fill(color);
+    ui->currentColorPatch->setPixmap(pm);
+    ui->htmlColor->setText(color.name());
+}

--- a/osmmapmakerapp/colorpickerdialog.h
+++ b/osmmapmakerapp/colorpickerdialog.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <QDialog>
+#include <QColor>
+#include <QListWidgetItem>
+
+class Project;
+
+namespace Ui {
+class ColorPickerDialog;
+}
+
+class ColorPickerDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit ColorPickerDialog(Project* project, QWidget* parent = nullptr);
+    ~ColorPickerDialog();
+
+    QColor selectedColor() const;
+    void setCurrentColor(const QColor& color);
+
+    static QColor getColor(Project* project, const QColor& initial, QWidget* parent = nullptr);
+
+private slots:
+    void on_usedColors_itemClicked(QListWidgetItem* item);
+    void on_usedColors_itemDoubleClicked(QListWidgetItem* item);
+    void on_colorWidget_currentColorChanged(const QColor& color);
+
+private:
+    void populateColors();
+    void updatePatch(const QColor& color);
+
+    Project* project_;
+    QColor color_;
+    Ui::ColorPickerDialog* ui;
+};

--- a/osmmapmakerapp/colorpickerdialog.ui
+++ b/osmmapmakerapp/colorpickerdialog.ui
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ColorPickerDialog</class>
+ <widget class="QDialog" name="ColorPickerDialog">
+  <property name="windowTitle">
+   <string>Select Color</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="currentColorPatch">
+     <property name="minimumSize">
+      <size>
+       <width>60</width>
+       <height>60</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QColorDialog" name="colorWidget">
+       <property name="options">
+        <set>QColorDialog::DontUseNativeDialog</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="vLayoutRight">
+       <item>
+        <widget class="QLineEdit" name="htmlColor"/>
+       </item>
+       <item>
+        <widget class="QListWidget" name="usedColors"/>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ColorPickerDialog</receiver>
+   <slot>accept()</slot>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ColorPickerDialog</receiver>
+   <slot>reject()</slot>
+  </connection>
+ </connections>
+</ui>

--- a/osmmapmakerapp/styleTab.cpp
+++ b/osmmapmakerapp/styleTab.cpp
@@ -4,7 +4,7 @@
 #include <QPainter>
 #include <QMouseEvent>
 #include <QMessageBox>
-#include <QColorDialog>
+#include "colorpickerdialog.h"
 
 #include <renderqt.h>
 #include "maputils.h"
@@ -96,6 +96,10 @@ void StyleTab::setProject(Project* project)
 
     ui->zoom->setValue(13);
     updatePixelResolutionFromZoom();
+
+    lineLabelPage_->setProject(project_);
+    areaLabelPage_->setProject(project_);
+    pointLabelPage_->setProject(project_);
 
     delete render_;
     render_ = NULL;
@@ -657,7 +661,7 @@ void StyleTab::on_mapBackgroundOpacity_valueChanged(double v)
 
 void StyleTab::on_mapBackgroundColorPick_clicked()
 {
-    QColor newColor = QColorDialog::getColor(QColor(ui->mapBackgroundColor->text()), this);
+    QColor newColor = ColorPickerDialog::getColor(project_, QColor(ui->mapBackgroundColor->text()), this);
 
     if (newColor.isValid()) {
         ui->mapBackgroundColor->setText(newColor.name());
@@ -733,7 +737,7 @@ void StyleTab::on_areaMinZoom_editingFinished()
 
 void StyleTab::on_areaColorPick_clicked()
 {
-    QColor newColor = QColorDialog::getColor(QColor(ui->areaColor->text()), this);
+    QColor newColor = ColorPickerDialog::getColor(project_, QColor(ui->areaColor->text()), this);
 
     if (newColor.isValid()) {
         ui->areaColor->setText(newColor.name());
@@ -743,7 +747,7 @@ void StyleTab::on_areaColorPick_clicked()
 
 void StyleTab::on_areaBorderColorPick_clicked()
 {
-    QColor newColor = QColorDialog::getColor(QColor(ui->areaBorderColor->text()), this);
+    QColor newColor = ColorPickerDialog::getColor(project_, QColor(ui->areaBorderColor->text()), this);
 
     if (newColor.isValid()) {
         ui->areaBorderColor->setText(newColor.name());
@@ -911,7 +915,7 @@ void StyleTab::on_lineMinZoom_editingFinished()
 
 void StyleTab::on_lineCasingColorPick_clicked()
 {
-    QColor newColor = QColorDialog::getColor(QColor(ui->lineCasingColor->text()), this);
+    QColor newColor = ColorPickerDialog::getColor(project_, QColor(ui->lineCasingColor->text()), this);
 
     if (newColor.isValid()) {
         ui->lineCasingColor->setText(newColor.name());
@@ -921,7 +925,7 @@ void StyleTab::on_lineCasingColorPick_clicked()
 
 void StyleTab::on_lineColorPick_clicked()
 {
-    QColor newColor = QColorDialog::getColor(QColor(ui->lineColor->text()), this);
+    QColor newColor = ColorPickerDialog::getColor(project_, QColor(ui->lineColor->text()), this);
 
     if (newColor.isValid()) {
         ui->lineColor->setText(newColor.name());

--- a/osmmapmakerapp/subLayerTextPage.cpp
+++ b/osmmapmakerapp/subLayerTextPage.cpp
@@ -1,13 +1,16 @@
 #include "subLayerTextPage.h"
 #include "ui_subLayerTextPage.h"
 
-#include <QColorDialog>
+#include "colorpickerdialog.h"
+#include <project.h>
 
 SubLayerTextPage::SubLayerTextPage(QWidget* parent)
     : QWidget(parent)
     , ui(new Ui::SubLayerTextPage)
 {
     ui->setupUi(this);
+
+    project_ = nullptr;
 
     suppressUpdates_ = true;
 
@@ -20,6 +23,11 @@ SubLayerTextPage::SubLayerTextPage(QWidget* parent)
 
 SubLayerTextPage::~SubLayerTextPage()
 {
+}
+
+void SubLayerTextPage::setProject(Project* project)
+{
+    project_ = project;
 }
 
 void SubLayerTextPage::on_hasLabel_clicked()
@@ -76,7 +84,7 @@ void SubLayerTextPage::on_fontWeight_currentIndexChanged(int i)
 
 void SubLayerTextPage::on_colorPick_clicked()
 {
-    QColor newColor = QColorDialog::getColor(QColor(ui->color->text()), this);
+    QColor newColor = ColorPickerDialog::getColor(project_, QColor(ui->color->text()), this);
 
     if (newColor.isValid()) {
         ui->color->setText(newColor.name());
@@ -86,7 +94,7 @@ void SubLayerTextPage::on_colorPick_clicked()
 
 void SubLayerTextPage::on_haloColorPick_clicked()
 {
-    QColor newColor = QColorDialog::getColor(QColor(ui->haloColor->text()), this);
+    QColor newColor = ColorPickerDialog::getColor(project_, QColor(ui->haloColor->text()), this);
 
     if (newColor.isValid()) {
         ui->haloColor->setText(newColor.name());

--- a/osmmapmakerapp/subLayerTextPage.h
+++ b/osmmapmakerapp/subLayerTextPage.h
@@ -2,6 +2,7 @@
 
 #include <QWidget>
 #include "stylelayer.h"
+#include <project.h>
 
 namespace Ui {
 class SubLayerTextPage;
@@ -13,6 +14,8 @@ class SubLayerTextPage : public QWidget {
 public:
     SubLayerTextPage(QWidget* parent);
     ~SubLayerTextPage();
+
+    void setProject(Project* project);
 
     void SaveTo(Label* lb);
     void Load(const Label& lb);
@@ -37,5 +40,6 @@ private slots:
 
 private:
     bool suppressUpdates_;
+    Project* project_ = nullptr;
     Ui::SubLayerTextPage* ui;
 };


### PR DESCRIPTION
## Summary
- introduce `ColorPickerDialog` listing all project colors sorted by hue
- allow SubLayerTextPage and StyleTab to pick colors via new dialog
- wire project into label pages for color gathering
- hook dialog into CMake build
- update coverage report

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake --build bin/release -j$(nproc)`
- `ctest --test-dir bin/release`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/valgrind`
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake --build bin/coverage -j$(nproc)`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`
- `valgrind --tool=memcheck --quiet --suppressions=valgrind.supp bin/valgrind/tests/area_test`
- `valgrind --tool=helgrind --quiet --suppressions=valgrind.supp bin/valgrind/tests/hello_test`


------
https://chatgpt.com/codex/tasks/task_e_6868ae858a848330804e8bbf501f9c98