### PR TITLE
Add persistent geometry to color picker dialog

### DIFF
--- a/osmmapmakerapp/colorpickerdialog.h
+++ b/osmmapmakerapp/colorpickerdialog.h
@@ -27,6 +27,10 @@ private slots:
     void on_usedColors_itemDoubleClicked(QListWidgetItem* item);
     void on_colorWidget_currentColorChanged(const QColor& color);
 
+protected:
+    void moveEvent(QMoveEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
+
 private:
     void populateColors();
     void updatePatch(const QColor& color);


### PR DESCRIPTION
## Summary
- store and reuse ColorPickerDialog size and position relative to parent
- highlight initial color in the color list on startup

## Testing
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/debug -j$(nproc)`
- `cmake --build bin/coverage -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/coverage`
- `valgrind --tool=memcheck --quiet --suppressions=../../../valgrind.supp ./applicationpreferences_test`


------
https://chatgpt.com/codex/tasks/task_e_6869bf4adf248330a79e820646f83094