### PR TITLE
Fix color picker dialog issues

### DIFF
--- a/osmmapmakerapp/colorpickerdialog.cpp
+++ b/osmmapmakerapp/colorpickerdialog.cpp
@@ -28,7 +28,7 @@ ColorPickerDialog::ColorPickerDialog(Project* project, QWidget* parent)
             resize(lastSize);
             move(parent->pos() + lastOffset);
         } else {
-            QSize s(std::max(1000, parent->width()), std::max(1000, parent->height()));
+            QSize s(std::min(1000, parent->width()), std::min(1000, parent->height()));
             resize(s);
             move(parent->pos());
             lastSize = s;

--- a/osmmapmakerapp/styleTab.cpp
+++ b/osmmapmakerapp/styleTab.cpp
@@ -661,11 +661,13 @@ void StyleTab::on_mapBackgroundOpacity_valueChanged(double v)
 
 void StyleTab::on_mapBackgroundColorPick_clicked()
 {
-    QColor newColor = ColorPickerDialog::getColor(project_, QColor(ui->mapBackgroundColor->text()), this);
+    QString old = ui->mapBackgroundColor->text();
+    QColor newColor = ColorPickerDialog::getColor(project_, QColor(old), this);
 
-    if (newColor.isValid()) {
+    if (newColor.isValid() && newColor.name() != old) {
         ui->mapBackgroundColor->setText(newColor.name());
         on_mapBackgroundColor_editingFinished();
+        freshRender();
     }
 }
 
@@ -737,21 +739,25 @@ void StyleTab::on_areaMinZoom_editingFinished()
 
 void StyleTab::on_areaColorPick_clicked()
 {
-    QColor newColor = ColorPickerDialog::getColor(project_, QColor(ui->areaColor->text()), this);
+    QString old = ui->areaColor->text();
+    QColor newColor = ColorPickerDialog::getColor(project_, QColor(old), this);
 
-    if (newColor.isValid()) {
+    if (newColor.isValid() && newColor.name() != old) {
         ui->areaColor->setText(newColor.name());
         saveArea();
+        freshRender();
     }
 }
 
 void StyleTab::on_areaBorderColorPick_clicked()
 {
-    QColor newColor = ColorPickerDialog::getColor(project_, QColor(ui->areaBorderColor->text()), this);
+    QString old = ui->areaBorderColor->text();
+    QColor newColor = ColorPickerDialog::getColor(project_, QColor(old), this);
 
-    if (newColor.isValid()) {
+    if (newColor.isValid() && newColor.name() != old) {
         ui->areaBorderColor->setText(newColor.name());
         saveArea();
+        freshRender();
     }
 }
 
@@ -818,6 +824,18 @@ void StyleTab::on_pointVisible_clicked()
 void StyleTab::on_pointColor_editingFinished()
 {
     savePoint();
+}
+
+void StyleTab::on_pointColorPick_clicked()
+{
+    QString old = ui->pointColor->text();
+    QColor newColor = ColorPickerDialog::getColor(project_, QColor(old), this);
+
+    if (newColor.isValid() && newColor.name() != old) {
+        ui->pointColor->setText(newColor.name());
+        savePoint();
+        freshRender();
+    }
 }
 
 void StyleTab::on_pointWidth_editingFinished()
@@ -915,21 +933,25 @@ void StyleTab::on_lineMinZoom_editingFinished()
 
 void StyleTab::on_lineCasingColorPick_clicked()
 {
-    QColor newColor = ColorPickerDialog::getColor(project_, QColor(ui->lineCasingColor->text()), this);
+    QString old = ui->lineCasingColor->text();
+    QColor newColor = ColorPickerDialog::getColor(project_, QColor(old), this);
 
-    if (newColor.isValid()) {
+    if (newColor.isValid() && newColor.name() != old) {
         ui->lineCasingColor->setText(newColor.name());
         saveLine();
+        freshRender();
     }
 }
 
 void StyleTab::on_lineColorPick_clicked()
 {
-    QColor newColor = ColorPickerDialog::getColor(project_, QColor(ui->lineColor->text()), this);
+    QString old = ui->lineColor->text();
+    QColor newColor = ColorPickerDialog::getColor(project_, QColor(old), this);
 
-    if (newColor.isValid()) {
+    if (newColor.isValid() && newColor.name() != old) {
         ui->lineColor->setText(newColor.name());
         saveLine();
+        freshRender();
     }
 }
 

--- a/osmmapmakerapp/styleTab.h
+++ b/osmmapmakerapp/styleTab.h
@@ -80,6 +80,7 @@ private slots:
     // point
     void on_pointVisible_clicked();
     void on_pointColor_editingFinished();
+    void on_pointColorPick_clicked();
     void on_pointWidth_editingFinished();
     void on_pointOpacity_editingFinished();
     void on_pointFillImageOpacity_editingFinished();

--- a/osmmapmakerapp/subLayerTextPage.cpp
+++ b/osmmapmakerapp/subLayerTextPage.cpp
@@ -84,9 +84,10 @@ void SubLayerTextPage::on_fontWeight_currentIndexChanged(int i)
 
 void SubLayerTextPage::on_colorPick_clicked()
 {
-    QColor newColor = ColorPickerDialog::getColor(project_, QColor(ui->color->text()), this);
+    QString old = ui->color->text();
+    QColor newColor = ColorPickerDialog::getColor(project_, QColor(old), this);
 
-    if (newColor.isValid()) {
+    if (newColor.isValid() && newColor.name() != old) {
         ui->color->setText(newColor.name());
         emit editingFinished();
     }
@@ -94,9 +95,10 @@ void SubLayerTextPage::on_colorPick_clicked()
 
 void SubLayerTextPage::on_haloColorPick_clicked()
 {
-    QColor newColor = ColorPickerDialog::getColor(project_, QColor(ui->haloColor->text()), this);
+    QString old = ui->haloColor->text();
+    QColor newColor = ColorPickerDialog::getColor(project_, QColor(old), this);
 
-    if (newColor.isValid()) {
+    if (newColor.isValid() && newColor.name() != old) {
         ui->haloColor->setText(newColor.name());
         emit editingFinished();
     }

--- a/tests/coverage_report.txt
+++ b/tests/coverage_report.txt
@@ -4,8 +4,9 @@
 Filename                                       |Rate    Num|Rate  Num|Rate   Num
 mapmaker/project.h                             |50.0%     6| 0.0%   3|    -    0
 mapmaker/output.cpp                            |43.8%    16| 0.0%   6|    -    0
+mapmaker/demdata.cpp                           | 7.7%   155| 0.0%   7|    -    0
 mapmaker/osmdata.cpp                           | 8.5%   176| 0.0%  14|    -    0
-mapmaker/project.cpp                           |15.0%   193| 0.0%  25|    -    0
+mapmaker/project.cpp                           |13.8%   240| 0.0%  28|    -    0
 mapmaker/renderqt.cpp                          |    -     0|    -   0|    -    0
 mapmaker/maputils.cpp                          |50.0%     2| 0.0%   1|    -    0
 mapmaker/textfield.cpp                         | 4.5%    44| 0.0%   2|    -    0
@@ -24,4 +25,4 @@ mapmaker/applicationpreferences.cpp            |14.0%    43| 0.0%   6|    -    0
 mapmaker/osmdataextractdownload.cpp            |50.0%    10| 0.0%   4|    -    0
                                                |Lines      |Functions|Branches  
 bin/coverage/mapmaker/...mapmaker_resources.cpp|38.5%    13| 0.0%   5|    -    0
-                                         Total:|15.6%  1327| 0.0% 176|    -    0
+                                         Total:|14.7%  1589| 0.0% 195|    -    0


### PR DESCRIPTION
## Summary
- limit default ColorPickerDialog size to 1000x1000
- refresh map only when colors actually change
- handle point color picker button
- update coverage report

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug`
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/debug -j$(nproc)`
- `cmake --build bin/coverage -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `valgrind --tool=memcheck bin/valgrind/tests/hello_test`
- `valgrind --tool=helgrind bin/valgrind/tests/hello_test`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_6869c90c110083308d197dd4d07ce5ae