### PR TITLE
Add image output flow

### DIFF
--- a/osmmapmakerapp/outputTab.h
+++ b/osmmapmakerapp/outputTab.h
@@ -35,8 +35,17 @@ private slots:
     void on_tileOutputPathUseProjectDir_clicked();
     void on_tileSize_currentIndexChanged(int i);
 
+    // image signals
+    void on_imageWidth_editingFinished();
+    void on_imageHeight_editingFinished();
+    void on_imageLatTop_editingFinished();
+    void on_imageLatBottom_editingFinished();
+    void on_imageLongLeft_editingFinished();
+    void on_imageLongRight_editingFinished();
+
 private:
     void saveTile();
+    void saveImage();
     void saveDefaultPathIntoTilePath();
 
     bool surpressSelectionChange_;

--- a/osmmapmakerapp/outputTab.ui
+++ b/osmmapmakerapp/outputTab.ui
@@ -247,9 +247,108 @@
         </widget>
        </item>
       </layout>
-     </widget>
-     <widget class="QWidget" name="blankPage"/>
-    </widget>
+      </widget>
+      <widget class="QWidget" name="imagePage">
+       <layout class="QFormLayout" name="formLayout_image">
+        <item row="0" column="0" colspan="2">
+         <widget class="QGroupBox" name="imageOutputDir">
+          <property name="title">
+           <string>Output Directory</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_image">
+           <item>
+            <widget class="QCheckBox" name="imageOutputPathUseProjectDir">
+             <property name="text">
+              <string>Output In Project Directory</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="imageWidthLabel">
+          <property name="text">
+           <string>Width</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QSpinBox" name="imageWidth">
+          <property name="maximum">
+           <number>4096</number>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="imageHeightLabel">
+          <property name="text">
+           <string>Height</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QSpinBox" name="imageHeight">
+          <property name="maximum">
+           <number>4096</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QGroupBox" name="imageBoundingBox">
+          <property name="title">
+           <string>Bounding Box</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_image">
+           <item row="3" column="2">
+            <widget class="QDoubleSpinBox" name="imageLatBottom">
+             <property name="decimals">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="3">
+            <widget class="QDoubleSpinBox" name="imageLongRight">
+             <property name="decimals">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QDoubleSpinBox" name="imageLongLeft">
+             <property name="decimals">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_image_long">
+             <property name="text">
+              <string>Longitude</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="2">
+            <widget class="QDoubleSpinBox" name="imageLatTop">
+             <property name="decimals">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="QLabel" name="label_image_lat">
+             <property name="text">
+              <string>Latitude</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="blankPage"/>
+      </widget>
    </item>
   </layout>
  </widget>

--- a/osmmapmakerapp/resources.qrc
+++ b/osmmapmakerapp/resources.qrc
@@ -8,6 +8,8 @@
       <file>resources/downarrow.svg</file>
       <file>resources/leftarrow.svg</file>
       <file>resources/rightarrow.svg</file>
+      <file>resources/tile_output.svg</file>
+      <file>resources/image_output.svg</file>
       <!-- areaKeys.json and discarded.txt moved to mapmaker resources -->
     </qresource>
 </RCC>

--- a/osmmapmakerapp/resources/image_output.svg
+++ b/osmmapmakerapp/resources/image_output.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+ <rect x="1" y="1" width="14" height="14" stroke="currentColor" fill="none"/>
+ <circle cx="5" cy="5" r="2" fill="currentColor"/>
+ <path d="M1 11l3-3 4 4 2-2 5 5H1z" fill="currentColor"/>
+</svg>

--- a/osmmapmakerapp/resources/tile_output.svg
+++ b/osmmapmakerapp/resources/tile_output.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+ <rect x="1" y="1" width="6" height="6" stroke="currentColor" fill="none"/>
+ <rect x="9" y="1" width="6" height="6" stroke="currentColor" fill="none"/>
+ <rect x="1" y="9" width="6" height="6" stroke="currentColor" fill="none"/>
+ <rect x="9" y="9" width="6" height="6" stroke="currentColor" fill="none"/>
+</svg>

--- a/tests/coverage_report.txt
+++ b/tests/coverage_report.txt
@@ -4,8 +4,9 @@
 Filename                                       |Rate    Num|Rate  Num|Rate   Num
 mapmaker/project.h                             |50.0%     6| 0.0%   3|    -    0
 mapmaker/output.cpp                            |43.8%    16| 0.0%   6|    -    0
+mapmaker/demdata.cpp                           | 7.7%   155| 0.0%   7|    -    0
 mapmaker/osmdata.cpp                           | 8.5%   176| 0.0%  14|    -    0
-mapmaker/project.cpp                           |15.0%   193| 0.0%  25|    -    0
+mapmaker/project.cpp                           |13.8%   240| 0.0%  28|    -    0
 mapmaker/renderqt.cpp                          |    -     0|    -   0|    -    0
 mapmaker/maputils.cpp                          |50.0%     2| 0.0%   1|    -    0
 mapmaker/textfield.cpp                         | 4.5%    44| 0.0%   2|    -    0
@@ -24,4 +25,4 @@ mapmaker/applicationpreferences.cpp            |14.0%    43| 0.0%   6|    -    0
 mapmaker/osmdataextractdownload.cpp            |50.0%    10| 0.0%   4|    -    0
                                                |Lines      |Functions|Branches  
 bin/coverage/mapmaker/...mapmaker_resources.cpp|38.5%    13| 0.0%   5|    -    0
-                                         Total:|15.6%  1327| 0.0% 176|    -    0
+                                         Total:|14.7%  1589| 0.0% 195|    -    0


### PR DESCRIPTION
## Summary
- add icons for tile and image outputs
- support single image output in `OutputTab` UI
- store image dimensions and bounding box
- show correct icons and change button text based on output type
- update coverage report

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug`
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/debug -j$(nproc)`
- `cmake --build bin/coverage -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `valgrind --tool=memcheck --quiet --suppressions=valgrind.supp bin/valgrind/tests/hello_test` *(and other tests)*
- `valgrind --tool=helgrind --quiet --suppressions=valgrind.supp bin/valgrind/tests/hello_test` *(and other tests)*
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`

------
https://chatgpt.com/codex/tasks/task_e_6869cb81d3848330a824450c7cd6996b