### PR TITLE
Add Overpass data source option

### DIFF
--- a/osmmapmakerapp/dataTab.h
+++ b/osmmapmakerapp/dataTab.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QWidget>
+#include <QNetworkAccessManager>
 
 #include "project.h"
 
@@ -23,9 +24,12 @@ private slots:
     void on_OSMFileBrowse_clicked();
     void on_OSMFileImport_clicked();
     void on_OSMFileDelete_clicked();
+    void on_overpassImport_clicked();
+    void on_overpassDelete_clicked();
     void on_addDataSource_clicked();
     void on_dataSources_currentIndexChanged(int index);
     void on_OSMFileName_textChanged(QString text);
+    void on_overpassQuery_textChanged();
     void on_dataSourceUserRename_clicked();
     void on_dataSouceIDEdit_clicked();
 
@@ -34,6 +38,8 @@ private:
 
     Project* project_ = NULL;
     int currentIndex_;
+
+    QNetworkAccessManager networkManager_;
 
     Ui::DataTab* ui;
 };

--- a/osmmapmakerapp/dataTab.ui
+++ b/osmmapmakerapp/dataTab.ui
@@ -216,8 +216,112 @@
            </spacer>
           </item>
          </layout>
+          </widget>
+        <widget class="QWidget" name="pageOverpass">
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <item>
+           <widget class="QLabel" name="labelOverpass">
+            <property name="text">
+             <string>Overpass Query</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPlainTextEdit" name="overpassQuery">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>150</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_overpass">
+            <item>
+             <widget class="QPushButton" name="overpassImport">
+              <property name="minimumSize">
+               <size>
+                <width>180</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Import Data To Project</string>
+              </property>
+              <property name="icon">
+               <iconset resource="resources.qrc">
+                <normaloff>:/resources/download.svg</normaloff>:/resources/download.svg</iconset>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>16</width>
+                <height>16</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_overpass">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_overpass">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="overpassDelete">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Delete Data Source</string>
+            </property>
+            <property name="icon">
+             <iconset resource="resources.qrc">
+              <normaloff>:/resources/trashicon.svg</normaloff>:/resources/trashicon.svg</iconset>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_overpass2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>300</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
         </widget>
-       </widget>
+        </widget>
       </item>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_5">


### PR DESCRIPTION
## Summary
- add Overpass query page to `DataTab` UI
- support saving/loading overpass query and adding a data source via Overpass
- connect new Overpass controls in `DataTab`
- update coverage report

## Testing
- `cmake --build bin/release -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/coverage`


------
https://chatgpt.com/codex/tasks/task_e_6868a920f5508330bb25d347e8680853