### PR TITLE
Add Overpass data source option

### DIFF
--- a/osmmapmakerapp/dataTab.h
+++ b/osmmapmakerapp/dataTab.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QWidget>
+#include <QNetworkAccessManager>
 
 #include "project.h"
 
@@ -24,6 +25,9 @@ private slots:
     void on_OSMFileImport_clicked();
     void on_OSMFileDelete_clicked();
     void on_addDataSource_clicked();
+    void on_overpassImport_clicked();
+    void on_overpassDelete_clicked();
+    void on_overpassQuery_textChanged();
     void on_dataSources_currentIndexChanged(int index);
     void on_OSMFileName_textChanged(QString text);
     void on_dataSourceUserRename_clicked();
@@ -34,6 +38,8 @@ private:
 
     Project* project_ = NULL;
     int currentIndex_;
+
+    QNetworkAccessManager nam_;
 
     Ui::DataTab* ui;
 };

--- a/osmmapmakerapp/dataTab.ui
+++ b/osmmapmakerapp/dataTab.ui
@@ -217,6 +217,103 @@
           </item>
          </layout>
         </widget>
+        <widget class="QWidget" name="pageOverpass">
+         <layout class="QVBoxLayout" name="verticalLayout_overpass">
+          <item>
+           <widget class="QLabel" name="label_overpass">
+            <property name="text">
+             <string>Overpass Query</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPlainTextEdit" name="overpassQuery"/>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_overpass_import">
+            <item>
+             <widget class="QPushButton" name="overpassImport">
+              <property name="minimumSize">
+               <size>
+                <width>180</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Import Data To Project</string>
+              </property>
+              <property name="icon">
+               <iconset resource="resources.qrc">
+                <normaloff>:/resources/download.svg</normaloff>:/resources/download.svg</iconset>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>16</width>
+                <height>16</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_overpass">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_overpass">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="overpassDelete">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Delete Data Source</string>
+            </property>
+            <property name="icon">
+             <iconset resource="resources.qrc">
+              <normaloff>:/resources/trashicon.svg</normaloff>:/resources/trashicon.svg</iconset>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_overpass2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>300</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
        </widget>
       </item>
       <item>


### PR DESCRIPTION
## Summary
- allow adding a data source from Overpass API
- show Overpass query editor with multiline text
- support importing and deleting Overpass sources

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug`
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/debug -j$(nproc)`
- `cmake --build bin/coverage -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/coverage`
- `valgrind --tool=memcheck --suppressions=valgrind.supp bin/valgrind/tests/hello_test`
- `valgrind --tool=helgrind --suppressions=valgrind.supp bin/valgrind/tests/hello_test`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`

------
https://chatgpt.com/codex/tasks/task_e_6868a920f5508330bb25d347e8680853