### PR TITLE
Fix Overpass source schema

### DIFF
--- a/mapmaker/resources/project.xsd
+++ b/mapmaker/resources/project.xsd
@@ -29,6 +29,7 @@
         <xs:element ref="openStreetMapFileSource" minOccurs="0" maxOccurs="unbounded"/>
         <xs:element ref="openStreetMapDirectDownload" minOccurs="0" maxOccurs="unbounded"/>
         <xs:element ref="openStreetMapExtractDownload" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="overpassSource" minOccurs="0" maxOccurs="unbounded"/>
         <xs:element ref="elevationSource" minOccurs="0" maxOccurs="unbounded"/>
         <xs:element ref="tileOutput" minOccurs="0" maxOccurs="unbounded"/>
         <xs:element ref="imageOutput" minOccurs="0" maxOccurs="unbounded"/>
@@ -66,6 +67,18 @@
         <xs:element name="dataSource" type="xs:string"/>
         <xs:element name="lastUpdateDate" type="xs:dateTime" minOccurs="0"/>
         <xs:element name="importDurationS" type="nonNegativeInt" minOccurs="0"/>
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="overpassSource">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="dataSource" type="xs:string"/>
+        <xs:element name="lastUpdateDate" type="xs:dateTime" minOccurs="0"/>
+        <xs:element name="importDurationS" type="nonNegativeInt" minOccurs="0"/>
+        <xs:element name="overpassQuery" type="xs:string"/>
       </xs:sequence>
       <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>

--- a/tests/project_load_save_test.cpp
+++ b/tests/project_load_save_test.cpp
@@ -34,7 +34,8 @@ TEST_CASE("Valid project files load and save", "[Project]")
         QStringLiteral(SOURCE_DIR "/tests/project_xml_samples/valid/valid_line.osmmap.xml"),
         QStringLiteral(SOURCE_DIR "/tests/project_xml_samples/valid/valid_point.osmmap.xml"),
         QStringLiteral(SOURCE_DIR "/tests/project_xml_samples/valid/valid_area.osmmap.xml"),
-        QStringLiteral(SOURCE_DIR "/tests/project_xml_samples/valid/valid_image_output.osmmap.xml")
+        QStringLiteral(SOURCE_DIR "/tests/project_xml_samples/valid/valid_image_output.osmmap.xml"),
+        QStringLiteral(SOURCE_DIR "/tests/project_xml_samples/valid/valid_overpass.osmmap.xml")
     };
 
     for (const QString& fileName : files) {

--- a/tests/project_schema_test.cpp
+++ b/tests/project_schema_test.cpp
@@ -23,7 +23,8 @@ TEST_CASE("Project files validate against schema", "[ProjectSchema]")
 
     QStringList files = {
         QStringLiteral(SOURCE_DIR "/projects/groton-sat.osmmap.xml"),
-        QStringLiteral(SOURCE_DIR "/projects/groton-trail.osmmap.xml")
+        QStringLiteral(SOURCE_DIR "/projects/groton-trail.osmmap.xml"),
+        QStringLiteral(SOURCE_DIR "/tests/project_xml_samples/valid/valid_overpass.osmmap.xml")
     };
 
     for (const QString& fileName : files) {

--- a/tests/project_xml_samples/valid/valid_overpass.osmmap.xml
+++ b/tests/project_xml_samples/valid/valid_overpass.osmmap.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osmmapmakerproject>
+ <overpassSource name="over">
+  <dataSource>Primary</dataSource>
+  <overpassQuery>node(0,0,1,1);out;</overpassQuery>
+ </overpassSource>
+ <tileOutput name="pointTiles">
+  <maxZoom>18</maxZoom>
+  <minZoom>15</minZoom>
+  <tileSize>256</tileSize>
+  <resolution1x>true</resolution1x>
+  <resolution2x>false</resolution2x>
+  <directory></directory>
+ </tileOutput>
+ <map>
+  <layer dataSource="Primary" k="amenity" type="point">
+   <subLayer name="poi" visible="true" minZoom="15">
+    <selector>
+     <condition key="amenity">
+      <value>restaurant</value>
+     </condition>
+    </selector>
+    <point>
+     <image>poi.png</image>
+     <opacity>1</opacity>
+     <color>#ff0000</color>
+     <width>1</width>
+    </point>
+   </subLayer>
+  </layer>
+ </map>
+</osmmapmakerproject>


### PR DESCRIPTION
## Summary
- update project XML schema with `overpassSource` element
- add minimal sample project using overpass source
- ensure project schema and load/save tests validate overpass XML

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake --build bin/release -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/release`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/valgrind`
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake --build bin/coverage -j$(nproc)`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`
- `valgrind --tool=memcheck --quiet --suppressions=valgrind.supp bin/valgrind/tests/area_test` (and others)
- `valgrind --tool=helgrind --quiet --suppressions=valgrind.supp bin/valgrind/tests/area_test` (and others)


------
https://chatgpt.com/codex/tasks/task_e_6869daa172288330a2b9766828b834fb