### PR TITLE
Improve input source creation dialog

### DIFF
--- a/osmmapmakerapp/CMakeLists.txt
+++ b/osmmapmakerapp/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SRC_FILES
     newtoplevelstyle.cpp
     newprojectdialog.cpp
     outputtypedialog.cpp
+    inputtypedialog.cpp
     subLayerTextPage.cpp
     sublayerselectpage.cpp
     selectvalueeditdialog.cpp
@@ -27,6 +28,7 @@ set(UI_FILES
     newtoplevelstyle.ui
     newprojectdialog.ui
     outputtypedialog.ui
+    inputtypedialog.ui
     subLayerTextPage.ui
     sublayerselectpage.ui
     selectvalueeditdialog.ui

--- a/osmmapmakerapp/dataTab.cpp
+++ b/osmmapmakerapp/dataTab.cpp
@@ -4,6 +4,7 @@
 #include <QMessageBox>
 #include <QFileInfo>
 #include <QFileDialog>
+#include "inputtypedialog.h"
 #include <QInputDialog>
 #include <osmdatafile.h>
 #include <osmdataoverpass.h>
@@ -231,16 +232,12 @@ void DataTab::saveCurrent()
 
 void DataTab::on_addDataSource_clicked()
 {
-    QMessageBox msgBox(this);
-    msgBox.setWindowTitle(tr("Add Map Data Source"));
-    msgBox.setText(tr("Import map data from:"));
-    QPushButton* localButton = msgBox.addButton(tr("Local File"), QMessageBox::AcceptRole);
-    QPushButton* overButton = msgBox.addButton(tr("Overpass"), QMessageBox::AcceptRole);
-    msgBox.addButton(QMessageBox::Cancel);
-    msgBox.exec();
+    InputTypeDialog dlg(this);
+    if (dlg.exec() != QDialog::Accepted)
+        return;
 
-    if (msgBox.clickedButton() == localButton) {
-        QString fileName = QFileDialog::getOpenFileName(this, tr("Open OSM File"), "", tr("Image Files (*.osm.pbf *.osm)"));
+    if (dlg.choice() == InputTypeDialog::LocalFile) {
+        QString fileName = dlg.fileName();
         if (fileName.isEmpty())
             return;
 
@@ -297,7 +294,7 @@ void DataTab::on_addDataSource_clicked()
 
         src->setDataName(dataSourceName);
         project_->addDataSource(src);
-    } else if (msgBox.clickedButton() == overButton) {
+    } else if (dlg.choice() == InputTypeDialog::Overpass) {
         OsmDataOverpass* src = new OsmDataOverpass(&nam_);
 
         QString primarySourceName = DataSource::primarySourceName();

--- a/osmmapmakerapp/inputtypedialog.cpp
+++ b/osmmapmakerapp/inputtypedialog.cpp
@@ -1,0 +1,41 @@
+#include "inputtypedialog.h"
+#include "ui_inputtypedialog.h"
+#include <QFileDialog>
+#include <QDir>
+
+InputTypeDialog::InputTypeDialog(QWidget* parent)
+    : QDialog(parent)
+    , ui(new Ui::InputTypeDialog)
+{
+    ui->setupUi(this);
+    ui->localRadio->setChecked(true);
+    on_localRadio_toggled(true);
+}
+
+InputTypeDialog::~InputTypeDialog()
+{
+    delete ui;
+}
+
+InputTypeDialog::Choice InputTypeDialog::choice() const
+{
+    return ui->localRadio->isChecked() ? LocalFile : Overpass;
+}
+
+QString InputTypeDialog::fileName() const
+{
+    return ui->localFilePath->text();
+}
+
+void InputTypeDialog::on_localRadio_toggled(bool checked)
+{
+    ui->browseButton->setEnabled(checked);
+    ui->localFilePath->setEnabled(checked);
+}
+
+void InputTypeDialog::on_browseButton_clicked()
+{
+    QString file = QFileDialog::getOpenFileName(this, tr("Open OSM File"), QString(), tr("Image Files (*.osm.pbf *.osm)"));
+    if (!file.isEmpty())
+        ui->localFilePath->setText(QDir::toNativeSeparators(file));
+}

--- a/osmmapmakerapp/inputtypedialog.h
+++ b/osmmapmakerapp/inputtypedialog.h
@@ -1,0 +1,25 @@
+#pragma once
+#include <QDialog>
+
+namespace Ui {
+class InputTypeDialog;
+}
+
+class InputTypeDialog : public QDialog {
+    Q_OBJECT
+public:
+    explicit InputTypeDialog(QWidget* parent = nullptr);
+    ~InputTypeDialog();
+
+    enum Choice { LocalFile,
+        Overpass };
+    Choice choice() const;
+    QString fileName() const;
+
+private slots:
+    void on_localRadio_toggled(bool checked);
+    void on_browseButton_clicked();
+
+private:
+    Ui::InputTypeDialog* ui;
+};

--- a/osmmapmakerapp/inputtypedialog.ui
+++ b/osmmapmakerapp/inputtypedialog.ui
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>InputTypeDialog</class>
+ <widget class="QDialog" name="InputTypeDialog">
+  <property name="windowTitle">
+   <string>New Input</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QRadioButton" name="localRadio">
+     <property name="text">
+      <string>Local File</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="localLayout">
+     <item>
+      <widget class="QLineEdit" name="localFilePath"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="browseButton">
+       <property name="text">
+        <string>...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QRadioButton" name="overpassRadio">
+     <property name="text">
+      <string>Overpass</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>InputTypeDialog</receiver>
+   <slot>accept()</slot>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>InputTypeDialog</receiver>
+   <slot>reject()</slot>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
## Summary
- add InputTypeDialog with radio buttons to choose between local file and overpass input
- update DataTab to use the new dialog and enable selecting a file
- register new dialog in build system
- update coverage report

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake --build bin/release -j$(nproc)`
- `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build bin/debug -j$(nproc)`
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake --build bin/coverage -j$(nproc)`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_6869db00f0e88330a0c93f59667f15c8