### PR TITLE
Fix icon resource load

### DIFF
--- a/osmmapmakerapp/outputTab.cpp
+++ b/osmmapmakerapp/outputTab.cpp
@@ -8,9 +8,6 @@
 #include <QProgressDialog>
 #include <QApplication>
 
-static QIcon tileOutputIcon(QStringLiteral(":/resources/tile_output.svg"));
-static QIcon imageOutputIcon(QStringLiteral(":/resources/image_output.svg"));
-
 OutputTab::OutputTab(QWidget* parent)
     : QWidget(parent)
     , ui(new Ui::OutputTab)
@@ -45,9 +42,9 @@ void OutputTab::setProject(Project* project)
         QListWidgetItem* item = new QListWidgetItem(output->name());
         item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsEnabled);
         if (dynamic_cast<TileOutput*>(output))
-            item->setIcon(tileOutputIcon);
+            item->setIcon(QIcon(QStringLiteral(":/resources/tile_output.svg")));
         else if (dynamic_cast<ImageOutput*>(output))
-            item->setIcon(imageOutputIcon);
+            item->setIcon(QIcon(QStringLiteral(":/resources/image_output.svg")));
         ui->outputList->addItem(item);
     }
 
@@ -134,9 +131,9 @@ void OutputTab::on_outputNew_clicked()
     QListWidgetItem* item = new QListWidgetItem(out->name());
     item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsEnabled);
     if (dynamic_cast<TileOutput*>(out))
-        item->setIcon(tileOutputIcon);
+        item->setIcon(QIcon(QStringLiteral(":/resources/tile_output.svg")));
     else
-        item->setIcon(imageOutputIcon);
+        item->setIcon(QIcon(QStringLiteral(":/resources/image_output.svg")));
 
     ui->outputList->addItem(item);
     ui->outputList->setCurrentRow(ui->outputList->count() - 1);


### PR DESCRIPTION
## Summary
- fix tile/image icon loading by constructing QIcon at runtime

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake --build bin/release -j$(nproc)`
- `ctest --test-dir bin/release`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/valgrind`
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake --build bin/coverage -j$(nproc)`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`

------
https://chatgpt.com/codex/tasks/task_e_6869e8819e8083308c7d6280c22b5161