### PR TITLE
Improve color picker dialog

### DIFF
--- a/osmmapmakerapp/colorpickerdialog.h
+++ b/osmmapmakerapp/colorpickerdialog.h
@@ -35,6 +35,7 @@ private slots:
     void onValEdited();
     void onHtmlEdited();
     void onStandardPicker();
+    void onCssPicker();
     void onDismissHint();
     void onHeaderClicked(int index);
 

--- a/osmmapmakerapp/colorpickerdialog.ui
+++ b/osmmapmakerapp/colorpickerdialog.ui
@@ -34,7 +34,14 @@
      <item>
       <widget class="QPushButton" name="standardPicker">
        <property name="text">
-        <string>...</string>
+        <string>Pick</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="cssPicker">
+       <property name="text">
+        <string>CSS</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
## Summary
- tweak color patch palette so the preview fills the frame
- resize color icons and stretch the description column
- add CSS button and rename picker button
- resize the hint box automatically
- keep the color table stretched when the dialog resizes

## Testing
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/debug -j$(nproc)`
- `cmake --build bin/coverage -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `valgrind --tool=memcheck --quiet bin/valgrind/tests/hello_test`
- `valgrind --tool=helgrind --quiet bin/valgrind/tests/hello_test`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_6869eb4854e4833089c52419c007e8cd