### PR TITLE
Add DEM option to InputTypeDialog

### DIFF
--- a/osmmapmakerapp/dataTab.cpp
+++ b/osmmapmakerapp/dataTab.cpp
@@ -8,6 +8,7 @@
 #include <QInputDialog>
 #include <osmdatafile.h>
 #include <osmdataoverpass.h>
+#include <demdata.h>
 
 DataTab::DataTab(QWidget* parent)
     : QWidget(parent)
@@ -291,6 +292,50 @@ void DataTab::on_addDataSource_clicked()
                 ++cycle;
             } while (nameUsed);
         }
+
+        src->setDataName(dataSourceName);
+        project_->addDataSource(src);
+    } else if (dlg.choice() == InputTypeDialog::DemFile) {
+        QString fileName = dlg.fileName();
+        if (fileName.isEmpty())
+            return;
+
+        DemData* src = new DemData();
+        src->setFileName(fileName);
+
+        QString base = QFileInfo(fileName).baseName();
+        if (base.length() > 0)
+            base[0] = base[0].toUpper();
+
+        QString userName = tr("%0 DEM File").arg(base);
+        bool nameUsed = false;
+        int cycle = 2;
+        do {
+            nameUsed = false;
+            for (DataSource* output : project_->dataSources()) {
+                if (QString::compare(output->userName(), userName, Qt::CaseInsensitive) == 0)
+                    nameUsed = true;
+            }
+            if (nameUsed)
+                userName = tr("%0 %1 DEM File").arg(base).arg(cycle);
+            ++cycle;
+        } while (nameUsed);
+
+        src->setUserName(userName);
+
+        QString dataSourceName = base.toLower();
+        nameUsed = false;
+        cycle = 2;
+        do {
+            nameUsed = false;
+            for (DataSource* output : project_->dataSources()) {
+                if (QString::compare(output->dataName(), dataSourceName, Qt::CaseInsensitive) == 0)
+                    nameUsed = true;
+            }
+            if (nameUsed)
+                dataSourceName = QString("%0-%1").arg(base.toLower()).arg(cycle);
+            ++cycle;
+        } while (nameUsed);
 
         src->setDataName(dataSourceName);
         project_->addDataSource(src);

--- a/osmmapmakerapp/inputtypedialog.cpp
+++ b/osmmapmakerapp/inputtypedialog.cpp
@@ -10,6 +10,7 @@ InputTypeDialog::InputTypeDialog(QWidget* parent)
     ui->setupUi(this);
     ui->localRadio->setChecked(true);
     on_localRadio_toggled(true);
+    setFixedSize(200, 200);
 }
 
 InputTypeDialog::~InputTypeDialog()
@@ -19,7 +20,12 @@ InputTypeDialog::~InputTypeDialog()
 
 InputTypeDialog::Choice InputTypeDialog::choice() const
 {
-    return ui->localRadio->isChecked() ? LocalFile : Overpass;
+    if (ui->localRadio->isChecked())
+        return LocalFile;
+    else if (ui->overpassRadio->isChecked())
+        return Overpass;
+    else
+        return DemFile;
 }
 
 QString InputTypeDialog::fileName() const
@@ -29,8 +35,14 @@ QString InputTypeDialog::fileName() const
 
 void InputTypeDialog::on_localRadio_toggled(bool checked)
 {
-    ui->browseButton->setEnabled(checked);
-    ui->localFilePath->setEnabled(checked);
+    ui->browseButton->setEnabled(checked || ui->demRadio->isChecked());
+    ui->localFilePath->setEnabled(checked || ui->demRadio->isChecked());
+}
+
+void InputTypeDialog::on_demRadio_toggled(bool checked)
+{
+    ui->browseButton->setEnabled(checked || ui->localRadio->isChecked());
+    ui->localFilePath->setEnabled(checked || ui->localRadio->isChecked());
 }
 
 void InputTypeDialog::on_browseButton_clicked()

--- a/osmmapmakerapp/inputtypedialog.h
+++ b/osmmapmakerapp/inputtypedialog.h
@@ -11,13 +11,17 @@ public:
     explicit InputTypeDialog(QWidget* parent = nullptr);
     ~InputTypeDialog();
 
-    enum Choice { LocalFile,
-        Overpass };
+    enum Choice {
+        LocalFile,
+        Overpass,
+        DemFile
+    };
     Choice choice() const;
     QString fileName() const;
 
 private slots:
     void on_localRadio_toggled(bool checked);
+    void on_demRadio_toggled(bool checked);
     void on_browseButton_clicked();
 
 private:

--- a/osmmapmakerapp/inputtypedialog.ui
+++ b/osmmapmakerapp/inputtypedialog.ui
@@ -28,14 +28,21 @@
     </layout>
    </item>
    <item>
-    <widget class="QRadioButton" name="overpassRadio">
-     <property name="text">
-      <string>Overpass</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
+   <widget class="QRadioButton" name="overpassRadio">
+    <property name="text">
+     <string>Overpass</string>
+    </property>
+   </widget>
+  </item>
+  <item>
+   <widget class="QRadioButton" name="demRadio">
+    <property name="text">
+     <string>DEM File</string>
+    </property>
+   </widget>
+  </item>
+  <item>
+   <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>


### PR DESCRIPTION
## Summary
- allow selecting DEM files in the input source dialog
- fix dialog to be 200x200 pixels
- handle DEM data creation in DataTab

## Testing
- `cmake --build bin/release -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_6869eb967d948330a865a43b265e4cdb