### PR TITLE
Add image output file picker

### DIFF
--- a/osmmapmakerapp/outputTab.cpp
+++ b/osmmapmakerapp/outputTab.cpp
@@ -7,6 +7,8 @@
 #include "outputtypedialog.h"
 #include <QProgressDialog>
 #include <QApplication>
+#include <QFileDialog>
+#include <QDir>
 
 static QIcon tileOutputIcon(QStringLiteral(":/resources/tile_output.svg"));
 static QIcon imageOutputIcon(QStringLiteral(":/resources/image_output.svg"));
@@ -232,6 +234,18 @@ void OutputTab::on_tileSize_currentIndexChanged(int i)
         saveTile();
 }
 
+void OutputTab::on_pushButton_clicked()
+{
+    QString dir = QFileDialog::getExistingDirectory(this, tr("Tile Output Directory"),
+        ui->tilePath->text());
+    if (!dir.isEmpty()) {
+        ui->tilePath->setText(QDir::toNativeSeparators(dir));
+        ui->tileOutputPathUseProjectDir->setChecked(false);
+        ui->tilePath->setEnabled(true);
+        saveTile();
+    }
+}
+
 void OutputTab::on_imageWidth_editingFinished()
 {
     saveImage();
@@ -276,6 +290,18 @@ void OutputTab::on_imageOutputPathUseProjectDir_clicked()
         ui->imagePath->setEnabled(true);
     }
     saveImage();
+}
+
+void OutputTab::on_imagePathBrowse_clicked()
+{
+    QString file = QFileDialog::getSaveFileName(this, tr("Image Output File"), ui->imagePath->text(),
+        tr("Images (*.png *.jpg *.jpeg *.tif);;All Files (*)"));
+    if (!file.isEmpty()) {
+        ui->imagePath->setText(QDir::toNativeSeparators(file));
+        ui->imageOutputPathUseProjectDir->setChecked(false);
+        ui->imagePath->setEnabled(true);
+        saveImage();
+    }
 }
 
 void OutputTab::saveTile()

--- a/osmmapmakerapp/outputTab.h
+++ b/osmmapmakerapp/outputTab.h
@@ -34,6 +34,7 @@ private slots:
     void on_tilePath_editingFinished();
     void on_tileOutputPathUseProjectDir_clicked();
     void on_tileSize_currentIndexChanged(int i);
+    void on_pushButton_clicked();
 
     // image signals
     void on_imageWidth_editingFinished();
@@ -44,6 +45,7 @@ private slots:
     void on_imageLongRight_editingFinished();
     void on_imagePath_editingFinished();
     void on_imageOutputPathUseProjectDir_clicked();
+    void on_imagePathBrowse_clicked();
 
 private:
     void saveTile();

--- a/osmmapmakerapp/outputTab.ui
+++ b/osmmapmakerapp/outputTab.ui
@@ -275,6 +275,19 @@
               </property>
              </widget>
             </item>
+            <item>
+             <widget class="QPushButton" name="imagePathBrowse">
+              <property name="maximumSize">
+               <size>
+                <width>23</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>...</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </item>
          </layout>


### PR DESCRIPTION
## Summary
- support browsing for image output path

## Testing
- `cmake --build bin/release -j$(nproc)`
- `ctest --test-dir bin/release`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`

------
https://chatgpt.com/codex/tasks/task_e_6869ec3a7ec88330a1e29a54714ea78b