### PR TITLE
Remove unused Qt slots

### DIFF
--- a/osmmapmakerapp/styleTab.cpp
+++ b/osmmapmakerapp/styleTab.cpp
@@ -806,10 +806,6 @@ void StyleTab::saveArea()
 }
 
 ///////// point tab
-void StyleTab::on_pointUpdateMap_clicked()
-{
-    freshRender();
-}
 
 void StyleTab::on_editingFinishedPointLabel()
 {
@@ -844,11 +840,6 @@ void StyleTab::on_pointWidth_editingFinished()
 }
 
 void StyleTab::on_pointOpacity_editingFinished()
-{
-    savePoint();
-}
-
-void StyleTab::on_pointFillImageOpacity_editingFinished()
 {
     savePoint();
 }

--- a/osmmapmakerapp/styleTab.h
+++ b/osmmapmakerapp/styleTab.h
@@ -34,7 +34,6 @@ private slots:
     void on_treeDown_clicked();
 
     void on_styleTree_itemSelectionChanged();
-    void on_pointUpdateMap_clicked();
     void on_updateMap_clicked();
 
     // map
@@ -83,7 +82,6 @@ private slots:
     void on_pointColorPick_clicked();
     void on_pointWidth_editingFinished();
     void on_pointOpacity_editingFinished();
-    void on_pointFillImageOpacity_editingFinished();
 
 private:
     void showEvent(QShowEvent* event);


### PR DESCRIPTION
## Summary
- clean up StyleTab by removing unused Qt slot methods

## Testing
- `ctest --test-dir bin/release`


------
https://chatgpt.com/codex/tasks/task_e_6869ef440d748330a86efb838fba1ae5