### PR TITLE
Update color picker dialog

### DIFF
--- a/osmmapmakerapp/colorpickerdialog.ui
+++ b/osmmapmakerapp/colorpickerdialog.ui
@@ -29,21 +29,21 @@
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="htmlColor"/>
-     </item>
-     <item>
       <widget class="QPushButton" name="standardPicker">
        <property name="text">
-        <string>Pick</string>
+        <string>Pick...</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QPushButton" name="cssPicker">
        <property name="text">
-        <string>CSS</string>
+        <string>CSS...</string>
        </property>
       </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="htmlColor"/>
      </item>
     </layout>
    </item>
@@ -125,7 +125,7 @@
        <item>
         <widget class="QPushButton" name="dismissHint">
          <property name="text">
-          <string>Dismiss</string>
+          <string>Hide</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
## Summary
- reorder web/hex row buttons and add ellipsis
- disable table editing and support reverse sort
- fix hint height and rename hide button
- show CSS color name in preview

## Testing
- `cmake --build bin/release -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`
- `valgrind --tool=memcheck --quiet --suppressions=valgrind.supp <test>` *(fails: Conditional jump or move depends on uninitialised value(s))*

------
https://chatgpt.com/codex/tasks/task_e_6869f3702c1c8330b16accd85358c8f0