### PR TITLE
Fix style layer visibility buttons

### DIFF
--- a/osmmapmakerapp/styleTab.cpp
+++ b/osmmapmakerapp/styleTab.cpp
@@ -682,6 +682,7 @@ void StyleTab::on_layerShowAll_clicked()
 
     StyleLayer* layer = layers[index];
     layer->showAll();
+    freshRender();
 }
 
 void StyleTab::on_layerHideAll_clicked()
@@ -693,6 +694,7 @@ void StyleTab::on_layerHideAll_clicked()
 
     StyleLayer* layer = layers[index];
     layer->hideAll();
+    freshRender();
 }
 
 ////////// area tab


### PR DESCRIPTION
## Summary
- refresh map preview when pressing the Style tab "Show All"/"Hide All" buttons
- update coverage report

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake --build bin/release -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/release`
- `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build bin/debug -j$(nproc)`
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake --build bin/coverage -j$(nproc)`
- `ctest --output-on-failure --test-dir bin/coverage`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/valgrind`
- `valgrind --tool=helgrind --quiet --suppressions=valgrind.supp bin/valgrind/tests/hello_test`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_6869f69c27008330a0088bb4ccc0b23f