### PR TITLE
Move delete data source control

### DIFF
--- a/osmmapmakerapp/dataTab.cpp
+++ b/osmmapmakerapp/dataTab.cpp
@@ -131,6 +131,11 @@ void DataTab::on_overpassDelete_clicked()
     on_OSMFileDelete_clicked();
 }
 
+void DataTab::on_dataSourceDelete_clicked()
+{
+    on_OSMFileDelete_clicked();
+}
+
 void DataTab::on_OSMFileBrowse_clicked()
 {
     QString file = QFileDialog::getOpenFileName(this, tr("Open OSM File"), "", tr("Image Files (*.osm.pbf *.osm)"));

--- a/osmmapmakerapp/dataTab.h
+++ b/osmmapmakerapp/dataTab.h
@@ -27,6 +27,7 @@ private slots:
     void on_addDataSource_clicked();
     void on_overpassImport_clicked();
     void on_overpassDelete_clicked();
+    void on_dataSourceDelete_clicked();
     void on_overpassQuery_textChanged();
     void on_dataSources_currentIndexChanged(int index);
     void on_OSMFileName_textChanged(QString text);

--- a/osmmapmakerapp/dataTab.ui
+++ b/osmmapmakerapp/dataTab.ui
@@ -95,8 +95,19 @@
        </property>
       </widget>
      </item>
-    </layout>
-   </item>
+     <item>
+      <widget class="QPushButton" name="dataSourceDelete">
+       <property name="text">
+        <string>Delete Data Source</string>
+       </property>
+       <property name="icon">
+        <iconset resource="resources.qrc">
+         <normaloff>:/resources/trashicon.svg</normaloff>:/resources/trashicon.svg</iconset>
+       </property>
+      </widget>
+     </item>
+   </layout>
+  </item>
    <item>
     <widget class="QGroupBox" name="dataSourceGroup">
      <property name="title">
@@ -186,23 +197,6 @@
            </spacer>
           </item>
           <item>
-           <widget class="QPushButton" name="OSMFileDelete">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Delete Data Source</string>
-            </property>
-            <property name="icon">
-             <iconset resource="resources.qrc">
-              <normaloff>:/resources/trashicon.svg</normaloff>:/resources/trashicon.svg</iconset>
-            </property>
-           </widget>
-          </item>
-          <item>
            <spacer name="verticalSpacer_2">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -281,23 +275,6 @@
              </size>
             </property>
            </spacer>
-          </item>
-          <item>
-           <widget class="QPushButton" name="overpassDelete">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Delete Data Source</string>
-            </property>
-            <property name="icon">
-             <iconset resource="resources.qrc">
-              <normaloff>:/resources/trashicon.svg</normaloff>:/resources/trashicon.svg</iconset>
-            </property>
-           </widget>
           </item>
           <item>
            <spacer name="verticalSpacer_overpass2">


### PR DESCRIPTION
## Summary
- add `dataSourceDelete` control in DataTab UI next to rename button
- handle `on_dataSourceDelete_clicked` in DataTab
- remove old Delete buttons from data source pages

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake --build bin/release -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_6869f675b7888330abe77797c2c851e4