### PR TITLE
Improve map data source dialog

### DIFF
--- a/osmmapmakerapp/inputtypedialog.cpp
+++ b/osmmapmakerapp/inputtypedialog.cpp
@@ -10,7 +10,8 @@ InputTypeDialog::InputTypeDialog(QWidget* parent)
     ui->setupUi(this);
     ui->localRadio->setChecked(true);
     on_localRadio_toggled(true);
-    setFixedSize(200, 200);
+    resize(600, 250);
+    ui->localFilePath->setMinimumWidth(500);
 }
 
 InputTypeDialog::~InputTypeDialog()

--- a/osmmapmakerapp/inputtypedialog.ui
+++ b/osmmapmakerapp/inputtypedialog.ui
@@ -3,20 +3,30 @@
  <class>InputTypeDialog</class>
  <widget class="QDialog" name="InputTypeDialog">
   <property name="windowTitle">
-   <string>New Input</string>
+   <string>Add New Map Data Source</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QRadioButton" name="localRadio">
      <property name="text">
-      <string>Local File</string>
+      <string>Local OpenStreetMap files (osm, pbf)</string>
      </property>
     </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="localLayout">
+     <property name="leftMargin">
+      <number>20</number>
+     </property>
      <item>
-      <widget class="QLineEdit" name="localFilePath"/>
+      <widget class="QLineEdit" name="localFilePath">
+       <property name="minimumSize">
+        <size>
+         <width>500</width>
+         <height>0</height>
+        </size>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QPushButton" name="browseButton">
@@ -37,9 +47,22 @@
   <item>
    <widget class="QRadioButton" name="demRadio">
     <property name="text">
-     <string>DEM File</string>
+     <string>Digital Elevation Model (asc)</string>
     </property>
    </widget>
+  </item>
+  <item>
+   <spacer name="verticalSpacer">
+    <property name="orientation">
+     <enum>Qt::Vertical</enum>
+    </property>
+    <property name="sizeHint" stdset="0">
+     <size>
+      <width>20</width>
+      <height>20</height>
+     </size>
+    </property>
+   </spacer>
   </item>
   <item>
    <widget class="QDialogButtonBox" name="buttonBox">


### PR DESCRIPTION
## Summary
- update dialog title and options
- support larger file input
- reformat layout for better spacing

## Testing
- `cmake --build bin/release -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/coverage`
- `valgrind --tool=memcheck --suppressions=valgrind.supp bin/valgrind/tests/hello_test`
- `valgrind --tool=helgrind --suppressions=valgrind.supp bin/valgrind/tests/hello_test`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`

------
https://chatgpt.com/codex/tasks/task_e_6869f578fed483309a2fd962e723fbc5