### PR TITLE
Improve color picker sorting and text visibility

### DIFF
--- a/osmmapmakerapp/colorpickerdialog.h
+++ b/osmmapmakerapp/colorpickerdialog.h
@@ -38,6 +38,7 @@ private slots:
     void onCssPicker();
     void onDismissHint();
     void onHeaderClicked(int index);
+    void onHeaderDoubleClicked(int index);
 
 protected:
     void moveEvent(QMoveEvent* event) override;


### PR DESCRIPTION
## Summary
- allow double-click on color table headers to reverse sort order
- display current color name in bold with readable text color

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake --build bin/release -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`

------
https://chatgpt.com/codex/tasks/task_e_6869f97938748330bfce2cfe5ba4fec5