### PR TITLE
Fix color table icon alpha and hex field width

### DIFF
--- a/osmmapmakerapp/colorpickerdialog.cpp
+++ b/osmmapmakerapp/colorpickerdialog.cpp
@@ -25,6 +25,8 @@ ColorPickerDialog::ColorPickerDialog(Project* project, const QString& item,
     , ui(new Ui::ColorPickerDialog)
 {
     ui->setupUi(this);
+    int editWidth = ui->hueEdit->sizeHint().width();
+    ui->htmlColor->setFixedWidth(editWidth);
     ui->verticalLayout->setStretch(3, 1);
     ui->verticalLayout->setStretch(4, 0);
     project_ = project;
@@ -195,7 +197,9 @@ void ColorPickerDialog::populateColors()
     for (size_t i = 0; i < colors.size(); ++i) {
         const ColorInfo& info = colors[i];
         QPixmap pm(80, 80);
-        pm.fill(info.color);
+        QColor opaqueColor = info.color;
+        opaqueColor.setAlpha(255);
+        pm.fill(opaqueColor);
         QTableWidgetItem* itemColor = new QTableWidgetItem(QIcon(pm), "");
         itemColor->setData(Qt::UserRole, info.color);
         itemColor->setToolTip(info.features.join(", "));


### PR DESCRIPTION
## Summary
- remove alpha from table icons to prevent selection bleed
- match Web/hex edit width with the HSV edit fields

## Testing
- `cmake --build bin/release -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`

Some valgrind steps produced noisy thread errors and were truncated.


------
https://chatgpt.com/codex/tasks/task_e_6869ffa778b48330bb3fe6dde63e987a