### PR TITLE
Add icon to output tab "new" button

### DIFF
--- a/osmmapmakerapp/outputTab.ui
+++ b/osmmapmakerapp/outputTab.ui
@@ -36,11 +36,15 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_4">
         <item>
-         <widget class="QPushButton" name="outputNew">
-          <property name="text">
-           <string>New</string>
-          </property>
-         </widget>
+        <widget class="QPushButton" name="outputNew">
+         <property name="text">
+          <string>New</string>
+         </property>
+         <property name="icon">
+          <iconset resource="resources.qrc">
+           <normaloff>:/resources/plus.svg</normaloff>:/resources/plus.svg</iconset>
+         </property>
+        </widget>
         </item>
         <item>
          <spacer name="horizontalSpacer_7">


### PR DESCRIPTION
## Summary
- tweak `OutputTab.ui` so the 'New' button uses a plus icon
- update coverage report

## Testing
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/debug -j$(nproc)`
- `cmake --build bin/coverage -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `for t in hello_test textfieldprocessor_test tileoutput_test project_schema_test labelpriority_test stylelayer_test style_selector_test sublayer_test point_test line_test area_test label_test osmdata_test linebreaking_test project_load_save_test; do valgrind --tool=memcheck --suppressions=valgrind.supp bin/valgrind/tests/$t; done`
- `for t in hello_test textfieldprocessor_test tileoutput_test project_schema_test labelpriority_test stylelayer_test style_selector_test sublayer_test point_test line_test area_test label_test osmdata_test linebreaking_test project_load_save_test; do valgrind --tool=helgrind --suppressions=valgrind.supp bin/valgrind/tests/$t; done`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`

------
https://chatgpt.com/codex/tasks/task_e_686a013cb4008330adaffcb2b8800e86