### PR TITLE
Fix new project dialog path handling and layout

### DIFF
--- a/osmmapmakerapp/newprojectdialog.cpp
+++ b/osmmapmakerapp/newprojectdialog.cpp
@@ -21,7 +21,10 @@ NewProjectDialog::~NewProjectDialog()
 
 QString NewProjectDialog::projectPath() const
 {
-    return ui->projectPath->text();
+    QString path = ui->projectPath->text();
+    if (!path.endsWith(".osmmap.xml", Qt::CaseInsensitive))
+        path += ".osmmap.xml";
+    return path;
 }
 
 QString NewProjectDialog::templateName() const

--- a/osmmapmakerapp/newprojectdialog.ui
+++ b/osmmapmakerapp/newprojectdialog.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>NewProjectDialog</class>
  <widget class="QDialog" name="NewProjectDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>150</height>
+   </rect>
+  </property>
   <property name="windowTitle">
    <string>New Project</string>
   </property>
@@ -14,7 +22,11 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QLineEdit" name="projectPath"/>
+    <widget class="QLineEdit" name="projectPath">
+     <property name="minimumWidth">
+      <number>500</number>
+     </property>
+    </widget>
    </item>
    <item row="0" column="2">
     <widget class="QPushButton" name="browse">
@@ -34,6 +46,19 @@
     <widget class="QComboBox" name="templateBox"/>
    </item>
    <item row="2" column="0" colspan="3">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
## Summary
- ensure path has extension in `NewProjectDialog::projectPath`
- improve `newprojectdialog` layout and default geometry

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake --build bin/release -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/release`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/valgrind`
- `valgrind --tool=memcheck bin/valgrind/tests/hello_test`
- `valgrind --tool=helgrind bin/valgrind/tests/hello_test`
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake --build bin/coverage -j$(nproc)`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_686a02a201288330af6e3edcacd4d1eb