### PR TITLE
Fix color picker table icon transparency

### DIFF
--- a/osmmapmakerapp/colorpickerdialog.cpp
+++ b/osmmapmakerapp/colorpickerdialog.cpp
@@ -7,6 +7,7 @@
 #include <QMenu>
 #include <QPixmap>
 #include <QTableWidgetItem>
+#include <QIcon>
 #include <algorithm>
 
 struct ColorInfo {
@@ -62,6 +63,10 @@ ColorPickerDialog::ColorPickerDialog(Project* project, const QString& item,
     ui->hintBox->document()->setTextWidth(ui->hintBox->viewport()->width());
     ui->hintBox->setFixedHeight(100);
     ui->hintWidget->setVisible(showHint);
+
+    int editWidth = ui->hueEdit->sizeHint().width();
+    ui->htmlColor->setMinimumWidth(editWidth);
+    ui->htmlColor->setMaximumWidth(editWidth);
 
     ui->hueSlider->setRange(0, 359);
     ui->satSlider->setRange(0, 255);
@@ -195,8 +200,15 @@ void ColorPickerDialog::populateColors()
     for (size_t i = 0; i < colors.size(); ++i) {
         const ColorInfo& info = colors[i];
         QPixmap pm(80, 80);
-        pm.fill(info.color);
-        QTableWidgetItem* itemColor = new QTableWidgetItem(QIcon(pm), "");
+        QColor solid = info.color;
+        solid.setAlpha(255);
+        pm.fill(solid);
+        QIcon icon;
+        icon.addPixmap(pm, QIcon::Normal);
+        icon.addPixmap(pm, QIcon::Selected);
+        icon.addPixmap(pm, QIcon::Active);
+        icon.addPixmap(pm, QIcon::Disabled);
+        QTableWidgetItem* itemColor = new QTableWidgetItem(icon, "");
         itemColor->setData(Qt::UserRole, info.color);
         itemColor->setToolTip(info.features.join(", "));
         itemColor->setFlags(itemColor->flags() & ~Qt::ItemIsEditable);


### PR DESCRIPTION
## Summary
- keep color table icons fully opaque regardless of row selection
- lock Web/Hex field width to the same size as the HSV edit fields

## Testing
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/coverage`
- `valgrind --tool=helgrind --suppressions=valgrind.supp --error-exitcode=1 bin/valgrind/tests/hello_test`

------
https://chatgpt.com/codex/tasks/task_e_6869ffa778b48330bb3fe6dde63e987a