### PR TITLE
Add BoundingBoxDialog and map canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,25 @@ The project relies on the following libraries:
 Development and testing also require `clang-format`, `lcov`, and `valgrind`.
 
 On Debian-based systems you can install them with `install_dependencies_apt.sh`.
+
+## Bounding Box Dialog
+
+The `BoundingBoxDialog` provides an interactive way to select map extents using
+OpenStreetMap tiles. After the user confirms the selection the dialog exposes
+the chosen coordinates and an optional image of the area.
+
+```cpp
+BoundingBoxDialog dlg;
+if (dlg.exec() == QDialog::Accepted) {
+    BoundingBoxCoords box = dlg.selectedBox();
+    QImage img = dlg.selectedImage();
+    OsmDataOverpass over(&nam);
+    QString q = QString("node(%1,%2,%3,%4);out;")
+                    .arg(box.minLat)
+                    .arg(box.minLon)
+                    .arg(box.maxLat)
+                    .arg(box.maxLon);
+    over.setQuery(q);
+    over.importData(db);
+}
+```

--- a/mapmaker/maputils.cpp
+++ b/mapmaker/maputils.cpp
@@ -11,3 +11,32 @@ double metersPerPixel(double latDeg, int zoom)
 {
     return kInitialMetersPerPixel * std::cos(latDeg * kDegToRad) / std::pow(2.0, zoom);
 }
+
+TileXY lonLatToTile(double lonDeg, double latDeg, int zoom)
+{
+    double latRad = latDeg * kDegToRad;
+    double n = std::pow(2.0, zoom);
+    double x = (lonDeg + 180.0) / 360.0 * n;
+    double y = (1.0 - std::log(std::tan(latRad) + 1.0 / std::cos(latRad)) / M_PI) / 2.0 * n;
+    return { x, y };
+}
+
+void tileToLonLat(const TileXY& t, int zoom, double& lonDeg, double& latDeg)
+{
+    double n = std::pow(2.0, zoom);
+    lonDeg = t.x / n * 360.0 - 180.0;
+    double latRad = std::atan(std::sinh(M_PI * (1 - 2 * t.y / n)));
+    latDeg = latRad / kDegToRad;
+}
+
+QPointF lonLatToPixel(double lonDeg, double latDeg, int zoom, int tileSize)
+{
+    TileXY t = lonLatToTile(lonDeg, latDeg, zoom);
+    return QPointF(t.x * tileSize, t.y * tileSize);
+}
+
+void pixelToLonLat(const QPointF& p, int zoom, int tileSize, double& lonDeg, double& latDeg)
+{
+    TileXY t { p.x() / tileSize, p.y() / tileSize };
+    tileToLonLat(t, zoom, lonDeg, latDeg);
+}

--- a/mapmaker/maputils.h
+++ b/mapmaker/maputils.h
@@ -1,8 +1,26 @@
 #pragma once
 
 #include <cmath>
+#include <QPointF>
+
+struct TileXY {
+    double x;
+    double y;
+};
 
 /// Utility functions for geographic calculations.
 /// Returns the meters per pixel for a given latitude (degrees)
 /// and zoom level.
 double metersPerPixel(double latDeg, int zoom);
+
+/// Convert longitude/latitude to fractional tile coordinates at a zoom level.
+TileXY lonLatToTile(double lonDeg, double latDeg, int zoom);
+
+/// Convert tile coordinates back to longitude/latitude.
+void tileToLonLat(const TileXY& t, int zoom, double& lonDeg, double& latDeg);
+
+/// Convert longitude/latitude to pixel coordinates.
+QPointF lonLatToPixel(double lonDeg, double latDeg, int zoom, int tileSize = 256);
+
+/// Convert pixel coordinates to longitude/latitude.
+void pixelToLonLat(const QPointF& p, int zoom, int tileSize, double& lonDeg, double& latDeg);

--- a/osmmapmakerapp/CMakeLists.txt
+++ b/osmmapmakerapp/CMakeLists.txt
@@ -19,7 +19,9 @@ set(SRC_FILES
     subLayerTextPage.cpp
     sublayerselectpage.cpp
     selectvalueeditdialog.cpp
-    colorpickerdialog.cpp)
+    colorpickerdialog.cpp
+    mapcanvas.cpp
+    boundingboxdialog.cpp)
 set(UI_FILES
     mainwindow.ui
     dataTab.ui

--- a/osmmapmakerapp/boundingboxdialog.cpp
+++ b/osmmapmakerapp/boundingboxdialog.cpp
@@ -1,0 +1,85 @@
+#include "boundingboxdialog.h"
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QDoubleSpinBox>
+#include <QLabel>
+#include <QPushButton>
+#include <QGridLayout>
+
+BoundingBoxDialog::BoundingBoxDialog(QWidget* parent)
+    : QDialog(parent)
+    , canvas_(new MapCanvas(this))
+    , minLat_(new QDoubleSpinBox(this))
+    , minLon_(new QDoubleSpinBox(this))
+    , maxLat_(new QDoubleSpinBox(this))
+    , maxLon_(new QDoubleSpinBox(this))
+{
+    setWindowTitle(tr("Select Bounding Box"));
+    minLat_->setRange(-90.0, 90.0);
+    maxLat_->setRange(-90.0, 90.0);
+    minLon_->setRange(-180.0, 180.0);
+    maxLon_->setRange(-180.0, 180.0);
+    minLat_->setDecimals(6);
+    maxLat_->setDecimals(6);
+    minLon_->setDecimals(6);
+    maxLon_->setDecimals(6);
+
+    QVBoxLayout* main = new QVBoxLayout(this);
+    main->addWidget(canvas_);
+
+    QGridLayout* grid = new QGridLayout;
+    grid->addWidget(new QLabel(tr("Min Lat"), this), 0, 0);
+    grid->addWidget(minLat_, 0, 1);
+    grid->addWidget(new QLabel(tr("Min Lon"), this), 0, 2);
+    grid->addWidget(minLon_, 0, 3);
+    grid->addWidget(new QLabel(tr("Max Lat"), this), 1, 0);
+    grid->addWidget(maxLat_, 1, 1);
+    grid->addWidget(new QLabel(tr("Max Lon"), this), 1, 2);
+    grid->addWidget(maxLon_, 1, 3);
+    main->addLayout(grid);
+
+    QHBoxLayout* buttons = new QHBoxLayout;
+    QPushButton* reset = new QPushButton(tr("Reset"), this);
+    QPushButton* ok = new QPushButton(tr("OK"), this);
+    QPushButton* cancel = new QPushButton(tr("Cancel"), this);
+    buttons->addStretch();
+    buttons->addWidget(reset);
+    buttons->addWidget(ok);
+    buttons->addWidget(cancel);
+    main->addLayout(buttons);
+
+    connect(reset, &QPushButton::clicked, this, &BoundingBoxDialog::onReset);
+    connect(ok, &QPushButton::clicked, this, &BoundingBoxDialog::onConfirm);
+    connect(cancel, &QPushButton::clicked, this, &BoundingBoxDialog::onCancel);
+    connect(canvas_, &MapCanvas::boxChanged, this, &BoundingBoxDialog::canvasBoxChanged);
+
+    canvas_->setCenter(0.0, 0.0);
+    canvas_->setZoom(2);
+}
+
+void BoundingBoxDialog::onReset()
+{
+    canvas_->setCenter(0.0, 0.0);
+    canvas_->setZoom(2);
+}
+
+void BoundingBoxDialog::onConfirm()
+{
+    currentBox_ = canvas_->selection();
+    previewImage_ = canvas_->renderSelection();
+    accept();
+}
+
+void BoundingBoxDialog::onCancel()
+{
+    reject();
+}
+
+void BoundingBoxDialog::canvasBoxChanged(const BoundingBoxCoords& box)
+{
+    currentBox_ = box;
+    minLat_->setValue(box.minLat);
+    minLon_->setValue(box.minLon);
+    maxLat_->setValue(box.maxLat);
+    maxLon_->setValue(box.maxLon);
+}

--- a/osmmapmakerapp/boundingboxdialog.h
+++ b/osmmapmakerapp/boundingboxdialog.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <QDialog>
+#include <QImage>
+#include "mapcanvas.h"
+
+class QDoubleSpinBox;
+
+class BoundingBoxDialog : public QDialog {
+    Q_OBJECT
+public:
+    explicit BoundingBoxDialog(QWidget* parent = nullptr);
+
+    BoundingBoxCoords selectedBox() const { return currentBox_; }
+    QImage selectedImage() const { return previewImage_; }
+
+private slots:
+    void onReset();
+    void onConfirm();
+    void onCancel();
+    void canvasBoxChanged(const BoundingBoxCoords& box);
+
+private:
+    MapCanvas* canvas_;
+    QDoubleSpinBox *minLat_, *minLon_, *maxLat_, *maxLon_;
+    QImage previewImage_;
+    BoundingBoxCoords currentBox_;
+};

--- a/osmmapmakerapp/mapcanvas.cpp
+++ b/osmmapmakerapp/mapcanvas.cpp
@@ -1,0 +1,188 @@
+#include "mapcanvas.h"
+#include "maputils.h"
+#include <QPainter>
+#include <QMouseEvent>
+#include <QtMath>
+#include <QNetworkReply>
+
+namespace {
+constexpr int kTileSize = 256;
+}
+
+MapCanvas::MapCanvas(QWidget* parent)
+    : QWidget(parent)
+    , tileCache_(200)
+{
+    setMinimumSize(300, 200);
+}
+
+void MapCanvas::setCenter(double lat, double lon)
+{
+    centerLat_ = lat;
+    centerLon_ = lon;
+    update();
+}
+
+void MapCanvas::setZoom(int z)
+{
+    zoom_ = std::clamp(z, 0, 19);
+    update();
+}
+
+QPointF MapCanvas::lonLatToPixel(double lat, double lon) const
+{
+    TileXY tile = lonLatToTile(lon, lat, zoom_);
+    return QPointF(tile.x * kTileSize, tile.y * kTileSize);
+}
+
+void MapCanvas::pixelToLonLat(const QPointF& p, double& lat, double& lon) const
+{
+    TileXY t { p.x() / kTileSize, p.y() / kTileSize };
+    tileToLonLat(t, zoom_, lon, lat);
+}
+
+void MapCanvas::requestTile(int x, int y) const
+{
+    QString key = QString("%1/%2/%3").arg(zoom_).arg(x).arg(y);
+    if (tileCache_.contains(key) || pending_.contains(key))
+        return;
+    pending_.insert(key);
+    QNetworkRequest req(QUrl(QString("https://tile.openstreetmap.org/%1/%2/%3.png").arg(zoom_).arg(x).arg(y)));
+    QNetworkReply* reply = nam_.get(req);
+    connect(reply, &QNetworkReply::finished, this, [this, reply, key]() {
+        pending_.remove(key);
+        if (reply->error() == QNetworkReply::NoError) {
+            QPixmap* px = new QPixmap;
+            px->loadFromData(reply->readAll());
+            tileCache_.insert(key, px);
+        }
+        reply->deleteLater();
+        const_cast<MapCanvas*>(this)->update();
+    });
+}
+
+void MapCanvas::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    QPointF centerPx = lonLatToPixel(centerLat_, centerLon_);
+    QPointF topLeft = centerPx - QPointF(width() / 2.0, height() / 2.0);
+
+    int x0 = int(std::floor(topLeft.x() / kTileSize));
+    int y0 = int(std::floor(topLeft.y() / kTileSize));
+    int x1 = int(std::floor((topLeft.x() + width()) / kTileSize));
+    int y1 = int(std::floor((topLeft.y() + height()) / kTileSize));
+
+    for (int x = x0; x <= x1; ++x) {
+        for (int y = y0; y <= y1; ++y) {
+            int tx = (x % int(std::pow(2, zoom_)) + int(std::pow(2, zoom_))) % int(std::pow(2, zoom_));
+            int ty = (y % int(std::pow(2, zoom_)) + int(std::pow(2, zoom_))) % int(std::pow(2, zoom_));
+            QString key = QString("%1/%2/%3").arg(zoom_).arg(tx).arg(ty);
+            QPixmap* pix = tileCache_.object(key);
+            if (!pix)
+                requestTile(tx, ty);
+            if (pix)
+                p.drawPixmap(x * kTileSize - topLeft.x(), y * kTileSize - topLeft.y(), *pix);
+        }
+    }
+
+    if (selecting_ || (currentBox_.maxLat > currentBox_.minLat && currentBox_.maxLon > currentBox_.minLon)) {
+        QRect rect(selectStart_, selectEnd_);
+        p.setPen(Qt::red);
+        QColor fill = Qt::red;
+        fill.setAlpha(50);
+        p.fillRect(rect.normalized(), fill);
+        p.drawRect(rect.normalized());
+    }
+}
+
+void MapCanvas::mousePressEvent(QMouseEvent* e)
+{
+    if (e->button() == Qt::LeftButton && (e->modifiers() & Qt::ShiftModifier)) {
+        selecting_ = true;
+        selectStart_ = e->pos();
+        selectEnd_ = e->pos();
+        update();
+    } else if (e->button() == Qt::LeftButton) {
+        panning_ = true;
+        panStart_ = e->pos();
+        panLatStart_ = centerLat_;
+        panLonStart_ = centerLon_;
+    }
+}
+
+void MapCanvas::mouseMoveEvent(QMouseEvent* e)
+{
+    if (panning_) {
+        QPointF delta = e->pos() - panStart_;
+        QPointF centerPx = lonLatToPixel(panLatStart_, panLonStart_);
+        centerPx -= delta;
+        pixelToLonLat(centerPx, centerLat_, centerLon_);
+        update();
+    } else if (selecting_) {
+        selectEnd_ = e->pos();
+        update();
+    }
+}
+
+void MapCanvas::mouseReleaseEvent(QMouseEvent* e)
+{
+    if (panning_ && e->button() == Qt::LeftButton) {
+        panning_ = false;
+    } else if (selecting_ && e->button() == Qt::LeftButton) {
+        selecting_ = false;
+        selectEnd_ = e->pos();
+        QPointF tl = selectStart_;
+        QPointF br = selectEnd_;
+        if (tl.x() > br.x())
+            std::swap(tl.rx(), br.rx());
+        if (tl.y() > br.y())
+            std::swap(tl.ry(), br.ry());
+        double lat1, lon1, lat2, lon2;
+        pixelToLonLat(tl + QPointF(0, 0), lat2, lon1);
+        pixelToLonLat(br, lat1, lon2);
+        currentBox_.minLat = lat1;
+        currentBox_.maxLat = lat2;
+        currentBox_.minLon = lon1;
+        currentBox_.maxLon = lon2;
+        emit boxChanged(currentBox_);
+        update();
+    }
+}
+
+void MapCanvas::wheelEvent(QWheelEvent* e)
+{
+    int delta = e->angleDelta().y() / 120;
+    if (!delta)
+        return;
+    setZoom(zoom_ + delta);
+}
+
+QImage MapCanvas::renderSelection(int tileSize) const
+{
+    if (currentBox_.maxLat <= currentBox_.minLat || currentBox_.maxLon <= currentBox_.minLon)
+        return QImage();
+    QPointF tl = lonLatToPixel(currentBox_.maxLat, currentBox_.minLon);
+    QPointF br = lonLatToPixel(currentBox_.minLat, currentBox_.maxLon);
+    int w = int(br.x() - tl.x());
+    int h = int(br.y() - tl.y());
+    QImage img(w, h, QImage::Format_ARGB32);
+    img.fill(Qt::transparent);
+    QPainter p(&img);
+    int x0 = int(std::floor(tl.x() / tileSize));
+    int y0 = int(std::floor(tl.y() / tileSize));
+    int x1 = int(std::floor((br.x()) / tileSize));
+    int y1 = int(std::floor((br.y()) / tileSize));
+    for (int x = x0; x <= x1; ++x) {
+        for (int y = y0; y <= y1; ++y) {
+            int tx = (x % int(std::pow(2, zoom_)) + int(std::pow(2, zoom_))) % int(std::pow(2, zoom_));
+            int ty = (y % int(std::pow(2, zoom_)) + int(std::pow(2, zoom_))) % int(std::pow(2, zoom_));
+            QString key = QString("%1/%2/%3").arg(zoom_).arg(tx).arg(ty);
+            QPixmap* pix = tileCache_.object(key);
+            if (!pix)
+                requestTile(tx, ty);
+            if (pix)
+                p.drawPixmap(x * tileSize - tl.x(), y * tileSize - tl.y(), *pix);
+        }
+    }
+    return img;
+}

--- a/osmmapmakerapp/mapcanvas.h
+++ b/osmmapmakerapp/mapcanvas.h
@@ -1,0 +1,60 @@
+#pragma once
+#include <QWidget>
+#include <QCache>
+#include <QNetworkAccessManager>
+#include <QSet>
+#include <QImage>
+#include "maputils.h"
+
+struct BoundingBoxCoords {
+    double minLat;
+    double minLon;
+    double maxLat;
+    double maxLon;
+};
+
+class MapCanvas : public QWidget {
+    Q_OBJECT
+public:
+    explicit MapCanvas(QWidget* parent = nullptr);
+
+    void setCenter(double lat, double lon);
+    void setZoom(int z);
+    int zoom() const { return zoom_; }
+    BoundingBoxCoords selection() const { return currentBox_; }
+
+    QImage renderSelection(int tileSize = 256) const;
+
+signals:
+    void boxChanged(const BoundingBoxCoords&);
+
+protected:
+    void paintEvent(QPaintEvent*) override;
+    void mousePressEvent(QMouseEvent*) override;
+    void mouseMoveEvent(QMouseEvent*) override;
+    void mouseReleaseEvent(QMouseEvent*) override;
+    void wheelEvent(QWheelEvent*) override;
+
+private:
+    QPointF lonLatToPixel(double lat, double lon) const;
+    void pixelToLonLat(const QPointF& p, double& lat, double& lon) const;
+    void requestTile(int x, int y) const;
+
+    mutable QCache<QString, QPixmap> tileCache_;
+    mutable QSet<QString> pending_;
+    mutable QNetworkAccessManager nam_;
+
+    int zoom_ = 2;
+    double centerLat_ = 0.0;
+    double centerLon_ = 0.0;
+
+    bool panning_ = false;
+    QPoint panStart_;
+    double panLatStart_ = 0.0;
+    double panLonStart_ = 0.0;
+
+    bool selecting_ = false;
+    QPoint selectStart_;
+    QPoint selectEnd_;
+    BoundingBoxCoords currentBox_;
+};

--- a/tests/coverage_report.txt
+++ b/tests/coverage_report.txt
@@ -8,7 +8,7 @@ mapmaker/demdata.cpp                           | 7.7%   155| 0.0%   7|    -    0
 mapmaker/osmdata.cpp                           | 8.5%   176| 0.0%  14|    -    0
 mapmaker/project.cpp                           |13.6%   242| 0.0%  28|    -    0
 mapmaker/renderqt.cpp                          |    -     0|    -   0|    -    0
-mapmaker/maputils.cpp                          |50.0%     2| 0.0%   1|    -    0
+mapmaker/maputils.cpp                          |35.7%    14| 0.0%   3|    -    0
 mapmaker/textfield.cpp                         | 4.5%    44| 0.0%   2|    -    0
 mapmaker/stylelayer.cpp                        | 8.7%   530| 0.0%  45|    -    0
 mapmaker/tileoutput.cpp                        |23.9%    71| 0.0%  17|    -    0
@@ -25,4 +25,4 @@ mapmaker/applicationpreferences.cpp            |14.0%    43| 0.0%   6|    -    0
 mapmaker/osmdataextractdownload.cpp            |50.0%    10| 0.0%   4|    -    0
                                                |Lines      |Functions|Branches  
 bin/coverage/mapmaker/...mapmaker_resources.cpp|38.5%    13| 0.0%   5|    -    0
-                                         Total:|14.6%  1616| 0.0% 200|    -    0
+                                         Total:|14.7%  1628| 0.0% 202|    -    0

--- a/tests/maputils_test.cpp
+++ b/tests/maputils_test.cpp
@@ -16,3 +16,14 @@ TEST_CASE("metersPerPixel varies with latitude and zoom", "[maputils]")
     double expected = 156543.03392 * std::cos(lat * M_PI / 180.0) / std::pow(2.0, zoom);
     REQUIRE(metersPerPixel(lat, zoom) == Approx(expected).epsilon(0.00001));
 }
+
+TEST_CASE("lonLat to tile and back", "[maputils]")
+{
+    TileXY t = lonLatToTile(0.0, 0.0, 1);
+    REQUIRE(t.x == Approx(1.0));
+    REQUIRE(t.y == Approx(1.0));
+    double lon, lat;
+    tileToLonLat(t, 1, lon, lat);
+    REQUIRE(lon == Approx(0.0).margin(0.0001));
+    REQUIRE(lat == Approx(0.0).margin(0.0001));
+}


### PR DESCRIPTION
## Summary
- implement `MapCanvas` widget for tile display and box selection
- add `BoundingBoxDialog` to wrap `MapCanvas`
- expose coordinate conversion helpers in `maputils`
- update example usage in README
- extend unit tests for new utilities

## Testing
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/debug -j$(nproc)`
- `cmake --build bin/coverage -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/coverage`
- `valgrind --tool=memcheck bin/valgrind/tests/hello_test`
- `valgrind --tool=helgrind bin/valgrind/tests/hello_test`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_686a068a30bc833093ab1a066a7c7f80