### PR TITLE
Revert color picker transparency changes

### DIFF
--- a/osmmapmakerapp/colorpickerdialog.cpp
+++ b/osmmapmakerapp/colorpickerdialog.cpp
@@ -7,7 +7,6 @@
 #include <QMenu>
 #include <QPixmap>
 #include <QTableWidgetItem>
-#include <QIcon>
 #include <algorithm>
 
 struct ColorInfo {
@@ -26,8 +25,6 @@ ColorPickerDialog::ColorPickerDialog(Project* project, const QString& item,
     , ui(new Ui::ColorPickerDialog)
 {
     ui->setupUi(this);
-    int editWidth = ui->hueEdit->sizeHint().width();
-    ui->htmlColor->setFixedWidth(editWidth);
     ui->verticalLayout->setStretch(3, 1);
     ui->verticalLayout->setStretch(4, 0);
     project_ = project;
@@ -65,10 +62,6 @@ ColorPickerDialog::ColorPickerDialog(Project* project, const QString& item,
     ui->hintBox->document()->setTextWidth(ui->hintBox->viewport()->width());
     ui->hintBox->setFixedHeight(100);
     ui->hintWidget->setVisible(showHint);
-
-    int editWidth = ui->hueEdit->sizeHint().width();
-    ui->htmlColor->setMinimumWidth(editWidth);
-    ui->htmlColor->setMaximumWidth(editWidth);
 
     ui->hueSlider->setRange(0, 359);
     ui->satSlider->setRange(0, 255);
@@ -202,15 +195,8 @@ void ColorPickerDialog::populateColors()
     for (size_t i = 0; i < colors.size(); ++i) {
         const ColorInfo& info = colors[i];
         QPixmap pm(80, 80);
-        QColor solid = info.color;
-        solid.setAlpha(255);
-        pm.fill(solid);
-        QIcon icon;
-        icon.addPixmap(pm, QIcon::Normal);
-        icon.addPixmap(pm, QIcon::Selected);
-        icon.addPixmap(pm, QIcon::Active);
-        icon.addPixmap(pm, QIcon::Disabled);
-        QTableWidgetItem* itemColor = new QTableWidgetItem(icon, "");
+        pm.fill(info.color);
+        QTableWidgetItem* itemColor = new QTableWidgetItem(QIcon(pm), "");
         itemColor->setData(Qt::UserRole, info.color);
         itemColor->setToolTip(info.features.join(", "));
         itemColor->setFlags(itemColor->flags() & ~Qt::ItemIsEditable);


### PR DESCRIPTION
## Summary
- revert color picker icon transparency and control width changes
- update coverage report

## Testing
- `cmake -S . -B bin/release -DCMAKE_BUILD_TYPE=Release`
- `cmake -S . -B bin/debug -DCMAKE_BUILD_TYPE=Debug`
- `cmake -S . -B bin/coverage -DOSMMAPMAKER_ENABLE_COVERAGE=ON`
- `cmake -S . -B bin/valgrind -DOSMMAPMAKER_ENABLE_VALGRIND=ON`
- `cmake --build bin/release -j$(nproc)`
- `cmake --build bin/debug -j$(nproc)`
- `cmake --build bin/coverage -j$(nproc)`
- `cmake --build bin/valgrind -j$(nproc)`
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`


------
https://chatgpt.com/codex/tasks/task_e_686a0a1bb048833098c2bcfb887e2236