### PR TITLE
Fix README formatting and refine valgrind suppression

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-#osmmapmaker
+# osmmapmaker
 
-osmmapmaker is a desktop application for cre### Build
-
-Build each directory with `cmake --build bin/<type> -j$(nproc)`. maps directly from OpenStreetMap data. It aims to be simple enough that non-engineers can import OSM data, style their maps, and generate the tiles from within the application.
+osmmapmaker is a desktop application for creating maps directly from OpenStreetMap data. It aims to be simple enough that non-engineers can import OSM data, style their maps, and generate the tiles from within the application.
 
 The program includes its own stylesheet system, which is easier to use than Mapnik XML, CartoCSS, or Mapbox GL JS. Because the data is imported without filtering, any information available in OpenStreetMap can be used to build specialized maps.
 

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -49,7 +49,7 @@
    fun:_ZL22CATCH2_INTERNAL_TEST_0v
    fun:_ZN5Catch10RunContext20invokeActiveTestCaseEv
 }
-{
+{ 
    QtXmlSchemaLoadFromDevice
    Memcheck:Leak
    match-leak-kinds: definite
@@ -65,6 +65,18 @@
    fun:_ZN5Catch10RunContext7runTestERKNS_14TestCaseHandleE
    fun:_ZN5Catch7Session11runInternalEv
    fun:_ZN5Catch7Session3runEv
+}
+{ 
+   QtXmlSchemaLoadFromDevice_Catch2
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:_Znwm
+   obj:/usr/lib/x86_64-linux-gnu/libQt5XmlPatterns.so.5.15.13
+   obj:/usr/lib/x86_64-linux-gnu/libQt5XmlPatterns.so.5.15.13
+   obj:/usr/lib/x86_64-linux-gnu/libQt5XmlPatterns.so.5.15.13
+   obj:/usr/lib/x86_64-linux-gnu/libQt5XmlPatterns.so.5.15.13
+   fun:_ZN10QXmlSchema4loadEP9QIODeviceRK4QUrl
+   ...
 }
 {
    QtHelgrindAllRace


### PR DESCRIPTION
## Summary
- tidy up README heading and intro
- add suppression entry for QtXmlPatterns leak in valgrind.supp

## Testing
- `ctest --test-dir bin/release`
- `ctest --test-dir bin/valgrind`
- `ctest --output-on-failure --test-dir bin/release`
- `ctest --output-on-failure --test-dir bin/coverage`
- `lcov --capture --directory bin/coverage --output-file bin/coverage/coverage.info`
- `lcov --remove bin/coverage/coverage.info '/usr/*' '*/tests/*' --output-file bin/coverage/coverage.info`
- `lcov --list bin/coverage/coverage.info | sort -k2 > tests/coverage_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_688e33edc4888330939a62271772eaf7